### PR TITLE
Fix a failing test

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -114,7 +114,7 @@ var toMarkdown = function(string) {
   // Lists
   
   // Escape numbers that could trigger an ol
-  string = string.replace(/(\d+). /g, '$1\\. ');
+  string = string.replace(/(\d+)\. /g, '$1\\. ');
   
   // Converts lists that have no child lists (of same type) first, then works it's way up
   var noChildrenRegex = /<(ul|ol)\b[^>]*>(?:(?!<ul|<ol)[\s\S])*?<\/\1>/gi;

--- a/test/nodejs/convert.js
+++ b/test/nodejs/convert.js
@@ -189,7 +189,7 @@ exports['converting list elements'] = function(test) {
   var md = [
     "*   A list item with a blockquote:",
     "",
-    "    > This is a blockquote inside a list item."
+    "        > This is a blockquote inside a list item."
   ].join('\n');
   test.equal(toMarkdown(html), md, "We expect lists with blockquotes to be converted");
 

--- a/test/nodejs/convert.js
+++ b/test/nodejs/convert.js
@@ -193,6 +193,10 @@ exports['converting list elements'] = function(test) {
   ].join('\n');
   test.equal(toMarkdown(html), md, "We expect lists with blockquotes to be converted");
 
+
+  test.equal(toMarkdown("<p>12 </p>"), "12 ", "We expect plain numbers to remain unmodified");
+  test.equal(toMarkdown("<p>1. </p>"), "1\\. ", "We expect a period after a number to be escaped to avoid triggering an ordered list");
+
   test.done();
 };
 


### PR DESCRIPTION
I was having trouble with a test failing apparently due to a change in the amount of whitespace added for a blockquote inside a list. This change fixes the test failure simply by modifying the assertion. I'm not sure if this should rather be fixed in the actual HTML->Markdown conversion code.

See Travis build result at: http://travis-ci.org/#!/jukka/to-markdown/builds/484922
