### PR TITLE
Add a patterns for spans with inline bold/italic styles

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -70,6 +70,17 @@ var toMarkdown = function(string) {
             title = attrs.match(attrRegExp('title'));
         return '![' + (alt && alt[1] ? alt[1] : '') + ']' + '(' + src[1] + (title && title[1] ? ' "' + title[1] + '"' : '') + ')';
       }
+    },
+    {
+      patterns: 'span',
+      replacement: function(str, attrs, innerHTML) {
+        var style = attrs.match(attrRegExp('style'))[1];
+        if (style.indexOf('italic') > 0) {
+          return innerHTML ? '_' + innerHTML + '_' : '';
+        } else if (style.indexOf('bold') > 0) {
+          return innerHTML ? '**' + innerHTML + '**' : '';
+        }
+      }
     }
   ];
   


### PR DESCRIPTION
I've been using your code for a WYSIWYG that switches back and forth between that and markdown mode. In some browsers, the execCommand function which provides styling and other functionality to selected text in contentEditable elements inserts bolding/italicizing as a span containing an inline style. This should catch those.
