### PR TITLE
Escaping potential OL tags

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -112,9 +112,11 @@ var toMarkdown = function(string) {
   });
   
   // Lists
-  
+
   // Escape numbers that could trigger an ol
-  string = string.replace(/(\d+). /g, '$1\\. ');
+  // If there are more than three spaces before the code, it would be in a pre tag
+  // Make sure we are escaping the period not matching any character
+  string = string.replace(/^(\s{0,3}\d+)\. /g, '$1\\. ');
   
   // Converts lists that have no child lists (of same type) first, then works it's way up
   var noChildrenRegex = /<(ul|ol)\b[^>]*>(?:(?!<ul|<ol)[\s\S])*?<\/\1>/gi;

--- a/test/nodejs/convert.js
+++ b/test/nodejs/convert.js
@@ -83,12 +83,28 @@ exports['converting code blocks'] = function(test) {
 };
 
 exports['converting list elements'] = function(test) {
-  test.equal(toMarkdown('1986. What a great season.'), '1986\\. What a great season.','We expect numbers that could trigger an ol to be escaped');
   test.equal(toMarkdown("<ol>\n\t<li>Hello world</li>\n\t<li>Lorem ipsum</li>\n</ol>"), "1.  Hello world\n2.  Lorem ipsum", "We expect ol elements to be converted properly");
   test.equal(toMarkdown("<ul>\n\t<li>Hello world</li>\n\t<li>Lorem ipsum</li>\n</ul>"), "*   Hello world\n*   Lorem ipsum", "We expect ul elements with line breaks and tabs to be converted properly");
   test.equal(toMarkdown("<ul class='blargh'><li class='first'>Hello world</li><li>Lorem ipsum</li></ul>"), "*   Hello world\n*   Lorem ipsum", "We expect ul elements with attributes to be converted properly");
   test.equal(toMarkdown("<ul><li>Hello world</li><li>Lorem ipsum</li></ul><ul><li>Hello world</li><li>Lorem ipsum</li></ul>"), "*   Hello world\n*   Lorem ipsum\n\n*   Hello world\n*   Lorem ipsum", "We expect multiple ul elements to be converted properly");
   test.equal(toMarkdown("<ul><li><p>Hello world</p></li><li>Lorem ipsum</li></ul>"), "*   Hello world\n\n*   Lorem ipsum", "We expect li elements with ps to be converted properly");
+
+  var numsToTriggerOlHtml = [
+    "1986. What a great season.",
+    "Dont apply to links that end in numbers <a href='http://mygreatsite/users/55'>Like This</a> and have spaces after them",
+    "Or like an address 123. or anything",
+    "<pre><code>1234. Four spaces make a code block</code></pre>"
+  ].join('\n'),
+
+  numsToTriggerOlMd = [
+    "1986\\. What a great season.",
+    "Dont apply to links that end in numbers [Like This](http://mygreatsite/users/55) and have spaces after them",
+    "Or like an address 123. or anything",
+    "",
+    "    1234. Four spaces make a code block"
+  ].join('\n');
+
+  test.equal(toMarkdown(numsToTriggerOlHtml), numsToTriggerOlMd, 'We expect only the numbers that could trigger an ol to be escaped');
     
   var lisWithPsHtml = [
     "<ol>",


### PR DESCRIPTION
Escaping potential OL tags will now only perform the escape for numbers that should get escaped.

Before, anything ending with a `number + any character + a space` would get escaped, which lead to things like:

```
<a href="htttp://test.com/users/456">Edit</a> User
```

To become

```
[Edit](htttp://test.com/users/456\. User
```

Things like:

```
<pre><code>3. This is point three</code></pre>
```

To become

```
    3\. This is point three
```

Things like:

```
My number is 123.456.7890 Call me
```

To become

```
My number is 123.456.789\. Call me
```
