### PR TITLE
Fix numbers followed by a space being replaced

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -114,7 +114,7 @@ var toMarkdown = function(string) {
   // Lists
   
   // Escape numbers that could trigger an ol
-  string = string.replace(/(\d+). /g, '$1\\. ');
+  string = string.replace(/(\d+)\. /g, '$1\\. ');
   
   // Converts lists that have no child lists (of same type) first, then works it's way up
   var noChildrenRegex = /<(ul|ol)\b[^>]*>(?:(?!<ul|<ol)[\s\S])*?<\/\1>/gi;

--- a/test/tests.js
+++ b/test/tests.js
@@ -245,4 +245,9 @@ $(function(){
     ].join('\n');
     strictEqual(toMarkdown(html), md, "We expect html in blockquotes to be converted");
   });
+
+  test("bugs", function() {
+    var str = "123 abc";
+    equal(toMarkdown(str), str, "It should not eat numbers");
+  });
 });


### PR DESCRIPTION
There's a broken regex that would change numbers in strings such as "123 abc" to "12. abc".
