### PR TITLE
Fix <i> inside <h4>

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -78,7 +78,7 @@
 
         $matches.each(function(j, el) {
           var $el = $(el);
-          $el.replaceWith(ELEMENTS[i].replacement($el.html(), $el));
+          $el.before(ELEMENTS[i].replacement($el.html(), $el)).remove();
         });
       }
     }


### PR DESCRIPTION
Using jQuery v1.9.1, this piece of HTML makes CPU panic:

```
<h4><i></i> Test</h4>
```

This seems to fix the problem.
