### PR TITLE
Handle the case when an html attribute contains either " or '.

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -104,7 +104,7 @@ var toMarkdown = function(string) {
   }
 
   function attrRegExp(attr) {
-    return new RegExp(attr + '\\s*=\\s*["\']?([^"\']*)["\']?', 'i');
+    return new RegExp(attr + '\\s*=\\s*(?:(?:"(.*?)")|(?:\'(.*?)\'))?', 'i');
   }
 
   // Pre code blocks


### PR DESCRIPTION
I've just created a 2 cases regexp : 
- if the attribute is opened with an " so : seek for an enclosing "
- and the same thing with '.
