### PR TITLE
Add AMD support

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -187,7 +187,7 @@ var toMarkdown = function(string) {
 };
 
 if (typeof exports === 'object') {
-  module.exports = toMarkdown;
+  exports = module.exports = toMarkdown;
 }
 else if (typeof define === 'function' && define.amd) {
   define(function() {

--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -187,7 +187,7 @@ var toMarkdown = function(string) {
 };
 
 if (typeof exports === 'object') {
-  exports = module.exports = toMarkdown;
+  exports.toMarkdown = toMarkdown;
 }
 else if (typeof define === 'function' && define.amd) {
   define(function() {

--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -10,6 +10,8 @@ if (typeof he !== 'object' && typeof require === 'function') {
   var he = require('he');
 }
 
+;(function() {
+
 var toMarkdown = function(string) {
 
   var ELEMENTS = [
@@ -185,5 +187,15 @@ var toMarkdown = function(string) {
 };
 
 if (typeof exports === 'object') {
-  exports.toMarkdown = toMarkdown;
+  module.exports = toMarkdown;
 }
+else if (typeof define === 'function' && define.amd) {
+  define(function() {
+    return toMarkdown;
+  });
+}
+else {
+  this.toMarkdown = toMarkdown;
+}
+
+}).call(this);


### PR DESCRIPTION
Wraps `toMarkdown` global in closure and exposes it to Common, AMD and root (window et al).
