### PR TITLE
Fix image tags without a src attribute

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -72,7 +72,7 @@ var toMarkdown = function(string) {
         var src = attrs.match(attrRegExp('src')),
             alt = attrs.match(attrRegExp('alt')),
             title = attrs.match(attrRegExp('title'));
-        return '![' + (alt && alt[1] ? alt[1] : '') + ']' + '(' + src[1] + (title && title[1] ? ' "' + title[1] + '"' : '') + ')';
+        return src ? '![' + (alt && alt[1] ? alt[1] : '') + ']' + '(' + src[1] + (title && title[1] ? ' "' + title[1] + '"' : '') + ')' : str;
       }
     }
   ];

--- a/test/tests.js
+++ b/test/tests.js
@@ -50,6 +50,7 @@ test("converting img elements", function() {
 
   equal(toMarkdown("<img src='http://example.com/logo.png' alt='Example logo' />"), "![Example logo](http://example.com/logo.png)", "We expect img elements to be converted properly with alt attrs");
   equal(toMarkdown("<img src='http://example.com/logo.png' alt='Example logo' title='Example title' />"), "![Example logo](http://example.com/logo.png \"Example title\")", "We expect img elements to be converted properly with alt and title attrs");
+  equal(toMarkdown("<img>"), "<img>", "img tags without a src should not be converted");
 });
 
 test("converting anchor elements", function() {


### PR DESCRIPTION
img tags without a src attribute are currently throwing an exception.
This will, instead, just not convert the tag.
