### PR TITLE
Added newlines around div tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "keywords": "markdown",
   "author": "Dom Christie",
   "main": "src/to-markdown.js",
-  "version": "0.0.2",
+  "version": "0.0.3",
+  "repository":{
+    "type":"git",
+    "url":"https://github.com/domchristie/to-markdown.git"
+  },
   "dependencies": {
     "he": ">=0.4.1"
   },

--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -14,7 +14,7 @@ var toMarkdown = function(string) {
 
   var ELEMENTS = [
     {
-      patterns: 'p',
+      patterns: ['p','div'],
       replacement: function(str, attrs, innerHTML) {
         return innerHTML ? '\n\n' + innerHTML + '\n' : '';
       }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,3 +1,8 @@
+test("converting div elements", function() {
+  equal(toMarkdown("Lorem<div>ipsum</div>"), "Lorem\n\nipsum", "We expect div tags to be wrapped with two line breaks");
+  equal(toMarkdown("<div>Lorem ipsum</div>"), "Lorem ipsum", "We expect p tags to be wrapped with two line breaks");
+});
+
 test("converting p elements", function() {
   equal(toMarkdown("<p>Lorem ipsum</p>"), "Lorem ipsum", "We expect p tags to be wrapped with two line breaks");
   equal(toMarkdown("<p class='intro'>Lorem ipsum</p>"), "Lorem ipsum", "We expect p tags to be wrapped with two line breaks");


### PR DESCRIPTION
Fixes domchristie/to-markdown#49

Previously `div` tags were ignored.  Now they are treated the same way
`p` tags are treated.

Added matching test, bumped package.json version.

Added `repository` field to `package.json` so the repository is easier
to find from npm.

The test suite passes my new test, but breaks during the headless
browser tests (for me).  I suspect they will continue working as well as
they did before, and this is just an environment issue, because I didn't
change much.
