### PR TITLE
PR: br should be replaced with two spaces and newline

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -22,7 +22,7 @@ var toMarkdown = function(string) {
     {
       patterns: 'br',
       type: 'void',
-      replacement: '\n'
+      replacement: '  \n'
     },
     {
       patterns: 'h([1-6])',

--- a/test/tests.js
+++ b/test/tests.js
@@ -37,9 +37,9 @@ test("converting hr elements", function() {
 });
 
 test("converting br elements", function() {
-  equal(toMarkdown("Hello<br />world"), "Hello\nworld", "We expect br elements to be converted to \n");
-  equal(toMarkdown("Hello<br/>world"), "Hello\nworld", "We expect br elements to be converted to \n");
-  equal(toMarkdown("Hello<br>world"), "Hello\nworld", "We expect br elements to be converted to \n");
+  equal(toMarkdown("Hello<br />world"), "Hello  \nworld", "We expect br elements to be converted to: two spaces \n");
+  equal(toMarkdown("Hello<br/>world"), "Hello  \nworld", "We expect br elements to be converted to: two spaces \n");
+  equal(toMarkdown("Hello<br>world"), "Hello  \nworld", "We expect br elements to be converted to: two spaces \n");
 });
 
 test("converting img elements", function() {


### PR DESCRIPTION
In markdown, a br is represented by two spaces and a newline: '  \n'

I updated the code and tests to reflect this.
