### PR TITLE
Ensure that whitespaces are place outside of emphasized elements

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -50,13 +50,13 @@ var toMarkdown = function(string) {
     {
       patterns: ['b', 'strong'],
       replacement: function(str, attrs, innerHTML) {
-        return innerHTML ? '**' + innerHTML + '**' : '';
+        return innerHTML ? emphasizeString(innerHTML, '**') : '';
       }
     },
     {
       patterns: ['i', 'em'],
       replacement: function(str, attrs, innerHTML) {
-        return innerHTML ? '_' + innerHTML + '_' : '';
+        return innerHTML ? emphasizeString(innerHTML, '_') : '';
       }
     },
     {
@@ -105,6 +105,17 @@ var toMarkdown = function(string) {
 
   function attrRegExp(attr) {
     return new RegExp(attr + '\\s*=\\s*["\']?([^"\']*)["\']?', 'i');
+  }
+
+  function emphasizeString(string, emphChar) {
+    // ensure that whitespaces are placed outside of emphasized element
+    var trimmedString = trim(string);
+    var index = string.indexOf(trimmedString);
+    var leadingWhiteSpaces = string.substring(0,index);
+    var trailingWhiteSpaces = string.substring(index + trimmedString.length, string.length);
+    var outputstring = leadingWhiteSpaces + emphChar + trimmedString + emphChar + trailingWhiteSpaces;
+
+    return outputstring
   }
 
   // Pre code blocks
@@ -181,6 +192,14 @@ var toMarkdown = function(string) {
     string = string.replace(/\n\s+\n/g, '\n\n');
     string = string.replace(/\n{3,}/g, '\n\n'); // limit consecutive linebreaks to 2
     return string;
+  }
+
+  function trim(string) {
+    var string = string.replace(/^\s\s*/, ''),
+      ws = /\s/,
+      i = string.length;
+    while (ws.test(string.charAt(--i)));
+    return string.slice(0, i + 1);
   }
 
   return cleanUp(string);

--- a/test/nodejs/convert.js
+++ b/test/nodejs/convert.js
@@ -17,6 +17,11 @@ exports['converting emphasis elements'] = function(test) {
   test.equal(toMarkdown("<em id='one' class='cowabunga'>Hello world</em>"), "_Hello world_", "We expect <em id='one' class='cowabunga'>Hello world</em> to be converted to _Hello world_");
   test.equal(toMarkdown("<em id='one' class='cowabunga'></em>"), "", "We expect empty em tags to be removed");
 
+  test.equal(toMarkdown("<b> Hello world </b>"), " **Hello world** ", "We expect whitespaces to be placed outside of emphasis");
+  test.equal(toMarkdown("<b>Hello world </b>"), "**Hello world** ", "We expect whitespaces to be placed outside of emphasis");
+  test.equal(toMarkdown("<b> Hello world</b>"), " **Hello world**", "We expect whitespaces to be placed outside of emphasis");
+  test.equal(toMarkdown("<em> Hello world </em>"), " _Hello world_ ", "We expect whitespaces to be placed outside of emphasis");
+
   test.done();
 };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -12,6 +12,12 @@ test("converting emphasis elements", function() {
   equal(toMarkdown("<em>Hello world</em>"), "_Hello world_", "We expect <em>Hello world</em> to be converted to _Hello world_");
   equal(toMarkdown("<em id='one' class='cowabunga'>Hello world</em>"), "_Hello world_", "We expect <em id='one' class='cowabunga'>Hello world</em> to be converted to _Hello world_");
   equal(toMarkdown("<em id='one' class='cowabunga'></em>"), "", "We expect empty em tags to be removed");
+
+  // testing for whitespace support
+  equal(toMarkdown("<b> Hello world </b>"), " **Hello world** ", "We expect <b> Hello world </b> to be converted to  **Hello world** ");
+  equal(toMarkdown("<b>Hello world </b>"), "**Hello world** ", "We expect <b>Hello world </b> to be converted to **Hello world** ");
+  equal(toMarkdown("<b> Hello world</b>"), "**Hello world** ", "We expect <b> Hello world </b> to be converted to  **Hello world** ");
+  equal(toMarkdown("<em> Hello world </em>"), "_Hello world_", "We expect <em> Hello world </em> to be converted to  _Hello world_ ");
 });
 
 test("converting inline code elements", function() {


### PR DESCRIPTION
Markdown does not allow whitespace characters at the beginning or end of an emphasis (http://spec.commonmark.org/0.12/#emphasis-and-strong-emphasis). This pull requests moves leading and trailing whitespace characters outside of the emphasized elements.

This way all emphasized elements get converted to markdown correctly.
