### PR TITLE
Remove HTML comments

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -178,6 +178,7 @@ var toMarkdown = function(string) {
 
   function cleanUp(string) {
     string = string.replace(/^[\t\r\n]+|[\t\r\n]+$/g, ''); // trim leading/trailing whitespace
+    string = string.replace(/<!--[\s\S]*?-->/g, ''); // remove HTML comments
     string = string.replace(/\n\s+\n/g, '\n\n');
     string = string.replace(/\n{3,}/g, '\n\n'); // limit consecutive linebreaks to 2
     return string;


### PR DESCRIPTION
When using to-markdown on contenteditable elements, it is possible for HTML comments to be part of the string although they are not displayed in the browser. As a general rule, I think it's a good idea to remove HTML comments.
