### PR TITLE
Add support for GFM task lists

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -141,7 +141,9 @@ var toMarkdown = function(string) {
         if(lis[i]) {
           var prefix = (listType === 'ol') ? (i + 1) + ".  " : "*   ";
           lis[i] = lis[i].replace(/\s*<li[^>]*>([\s\S]*)/i, function(str, innerHTML) {
-
+            innerHTML = innerHTML.replace(/\s*<input[^>]*?(checked[^>]*)?type=['"]?checkbox['"]?[^>]>/, function(inputStr, checked){
+                  return checked ? '[X]' : '[ ]';
+            });
             innerHTML = innerHTML.replace(/^\s+/, '');
             innerHTML = innerHTML.replace(/\n\n/g, '\n\n    ');
             // indent nested lists


### PR DESCRIPTION
This PR add support for [GFM task lists](https://help.github.com/articles/writing-on-github/#task-lists), like the ones used on GitHub.

This only works on list elements (`ul` or `ol`) with list items starting with a checkbox;

**An incomplete task**
`<input type="checkbox">`, resulting in `*  [ ]` depending on the listType.

**Completed task**
`<input checked type="checkbox">`, resulting in `*  [X]` depending on the listType. 
Conform W3C standards, a checkbox is checked with the use of `checked`-attribute. It doesn't matter what value it has.
