### PR TITLE
Fix vanishing whitespace between inline elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,11 @@ function removeBlankNodes(node) {
       break;
     case 1: // Element node
     case 9: // Document node
+      // Trim block-level
+      if (node.tagName !== 'PRE' && isBlockLevel(node)) {
+        node.innerHTML = node.innerHTML.replace(/^\s+|\s+$/, '');
+      }
+
       child = node.firstChild;
       while (child) {
         next = child.nextSibling;

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var htmlToDom = require('./lib/html-to-dom');
 var converters = require('./lib/md-converters');
 
 var isRegExp = require('./lib/utilities').isRegExp;
+var isBlockLevel = require('./lib/utilities').isBlockLevel;
 
 var VOID_ELEMENTS = [
   'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',

--- a/index.js
+++ b/index.js
@@ -117,16 +117,23 @@ function removeBlankNodes(node) {
   var child, next;
   switch (node.nodeType) {
     case 3: // Text node
-      var parentTagName = node.parentNode.tagName;
-      if (parentTagName !== 'PRE' && parentTagName !== 'CODE') {
+      var parent = node.parentNode;
+      if (parent.tagName !== 'PRE' && parent.tagName !== 'CODE') {
+        var prevSibling = node.previousSibling;
+        var nextSibling = node.nextSibling;
+        var hasAdjacentBlockSibling = (prevSibling && isBlockLevel(prevSibling)) ||
+                                      (nextSibling && isBlockLevel(nextSibling));
         var value = node.nodeValue;
+
         if (/\S/.test(value)) {
-          node.nodeValue = value.replace(/^[\n\r\t\f]+\s*/gm, '')
-                                .replace(/[\n\r\t\f]+/gm, ' ')
-                                .replace(/ {2,}/gm, ' ');
+          node.nodeValue = value.replace(/\s+/gm, ' ');
+        }
+        else if (hasAdjacentBlockSibling) {
+          // Remove any empty text nodes that are adjacent to block-level nodes
+          parent.removeChild(node);
         }
         else {
-          node.parentNode.removeChild(node);
+          node.nodeValue = ' ';
         }
       }
       break;

--- a/lib/md-converters.js
+++ b/lib/md-converters.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var trim = require('./utilities').trim;
-
 module.exports = [
   {
     filter: 'p',
@@ -101,7 +99,8 @@ module.exports = [
   {
     filter: 'blockquote',
     replacement: function (innerHTML) {
-      innerHTML = trim(innerHTML);
+      // Trim
+      innerHTML = innerHTML.replace(/^\s+|\s+$/g, '');
       innerHTML = innerHTML.replace(/\n{3,}/g, '\n\n');
       innerHTML = innerHTML.replace(/^/gm, '> ');
       return '\n' + innerHTML + '\n\n';

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -4,6 +4,7 @@ exports.isRegExp = function (obj) {
   return Object.prototype.toString.call(obj) === '[object RegExp]';
 };
 
-exports.trim = function (string) {
-  return string.replace(/^\s+|\s+$/g, '');
+var blockRegex = /^(address|article|aside|audio|blockquote|body|canvas|center|dd|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frameset|h[1-6]|header|hgroup|hr|html|isindex|li|main|menu||nav|noframes|noscript|ol|output|p|pre|section|table|tbody|td|tfoot|th|thead|tr|ul)$/i;
+exports.isBlockLevel = function (node) {
+  return blockRegex.test(node.nodeName);
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.isRegExp = function (obj) {
   return Object.prototype.toString.call(obj) === '[object RegExp]';
 };

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -293,8 +293,8 @@ test('comments', function () {
 test('leading/trailing whitespace', function() {
   var html, md;
 
-  html = '<p>I <a href="http://example.com">need</a> a space</p>';
-  md = 'I [need](http://example.com) a space';
+  html = '<p>I <a href="http://example.com">need</a> <a href="http://www.example.com">more</a> spaces!</p>';
+  md = 'I [need](http://example.com) [more](http://www.example.com) spaces!';
   equal(toMarkdown(html), md, 'Inline elements');
 
   html = [


### PR DESCRIPTION
Fixes #70 

This improves the approach to removing whitespace nodes, only removing them if they are situated next to a block-level element.

I think this can be improved further (some minor tests re: trailing whitespace are still failing), but it’s probably good enough for most situations.
