### PR TITLE
Improve list conversion

### DIFF
--- a/lib/md-converters.js
+++ b/lib/md-converters.js
@@ -116,7 +116,7 @@ module.exports = [
       innerHTML = innerHTML.replace(/^\s+/, '').replace(/\n/gm, '\n    ');
       var prefix = '*   ';
       var parent = node.parentNode;
-      var index = Array.prototype.indexOf.call(parent.childNodes, node) + 1;
+      var index = Array.prototype.indexOf.call(parent.children, node) + 1;
 
       prefix = /ol/i.test(parent.tagName) ? index + '.  ' : '*   ';
       return prefix + innerHTML;


### PR DESCRIPTION
Use `children` rather than `childNodes` for calculating li index (i.e. ignore non-element nodes)
