### PR TITLE
Add support for strikethrough

### DIFF
--- a/lib/md-converters.js
+++ b/lib/md-converters.js
@@ -49,7 +49,7 @@ module.exports = [
   },
 
   {
-    filter: ['strike', 'del'],
+    filter: ['strike', 'del', 's'],
     replacement: function(innerHTML) {
       return '~~' + innerHTML + '~~';
     }

--- a/lib/md-converters.js
+++ b/lib/md-converters.js
@@ -48,6 +48,13 @@ module.exports = [
     }
   },
 
+  {
+    filter: ['strike', 'del'],
+    replacement: function(innerHTML) {
+      return '~~' + innerHTML + '~~';
+    }
+  },
+
   // Inline code
   {
     filter: function (node) {

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -37,6 +37,7 @@ test('strikethrough', function() {
   runTestCases([
     ['<del>Hello world</del>', '~~Hello world~~', 'del'],
     ['<strike>Hello world</strike>', '~~Hello world~~', 'strike'],
+    ['<s>Hello world</s>', '~~Hello world~~', 's'],
     ['<del><b>Hello world</b></del>', '~~**Hello world**~~', 'del with child']
   ]);
 });

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -33,6 +33,14 @@ test('emphasis', function() {
   ]);
 });
 
+test('strikethrough', function() {
+  runTestCases([
+    ['<del>Hello world</del>', '~~Hello world~~', 'del'],
+    ['<strike>Hello world</strike>', '~~Hello world~~', 'strike'],
+    ['<del><b>Hello world</b></del>', '~~**Hello world**~~', 'del with child']
+  ]);
+});
+
 test('code', function() {
   runTestCases([
     ['<code>print()</code>', '`print()`']


### PR DESCRIPTION
Changes will add support for ~~strikethrough~~ to the code, by converting the 'strike', 's' and 'del' tags to the double tilde markup.
