### PR TITLE
Prevent rebuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,8 +192,6 @@ function flankingWhitespace(node) {
     var hasLeading = /^[ \r\n\t]/.test(node.innerHTML),
         hasTrailing = /[ \r\n\t]$/.test(node.innerHTML);
 
-    node.innerHTML = trim(node.innerHTML);
-
     if (hasLeading && !isFlankedByWhitespace('left', node)) {
       leading = ' ';
     }

--- a/index.js
+++ b/index.js
@@ -125,7 +125,6 @@ function bfsOrder(node) {
 
 function getContent(node) {
   var text = '';
-
   for (var i = 0; i < node.childNodes.length; i++) {
     if (node.childNodes[i].nodeType === 1) {
       text += node.childNodes[i]._replacement;
@@ -143,7 +142,6 @@ function getContent(node) {
  */
 
 function outer(node, content) {
-  content = content || getContent(node);
   return node.cloneNode(false).outerHTML.replace('><', '>'+ content +'<');
 }
 
@@ -204,37 +202,40 @@ function flankingWhitespace(node) {
 }
 
 /*
- * Finds a Markdown replacement if one exists, and sets it on `_replacement`
+ * Finds a Markdown converter, gets its replacement, and sets it on
+ * `_replacement`
  */
 
 function process(node) {
-  var replacement;
+  var replacement, content = getContent(node);
 
-  // Remove blank, non-anchor nodes
-  if (!isVoid(node) && !/A/.test(node.nodeName) && /^\s*$/i.test(getContent(node))) {
-    replacement = '';
-  }
-  else {
-    for (var i = 0; i < converters.length; i++) {
-      var converter = converters[i];
+  for (var i = 0; i < converters.length; i++) {
+    var converter = converters[i];
 
-      if (canConvert(node, converter.filter)) {
-        if (typeof converter.replacement !== 'function') {
-          throw new TypeError(
-            '`replacement` needs to be a function that returns a string'
-          );
-        }
-
-        var whitespace = flankingWhitespace(node);
-
-        replacement = converter.replacement.call(toMarkdown, getContent(node), node);
-        replacement = whitespace.leading + replacement + whitespace.trailing;
-        break;
+    if (canConvert(node, converter.filter)) {
+      if (typeof converter.replacement !== 'function') {
+        throw new TypeError(
+          '`replacement` needs to be a function that returns a string'
+        );
       }
+
+      var whitespace = flankingWhitespace(node);
+
+      if (whitespace.leading || whitespace.trailing) {
+        content = trim(content);
+      }
+      replacement = converter.replacement.call(toMarkdown, content, node);
+      replacement = whitespace.leading + replacement + whitespace.trailing;
+      break;
     }
   }
 
-  node._replacement = (typeof replacement === 'string') ? replacement : outer(node);
+  // Remove blank nodes
+  if (!isVoid(node) && !/A/.test(node.nodeName) && /^\s*$/i.test(content)) {
+    replacement = '';
+  }
+
+  node._replacement = replacement;
 }
 
 toMarkdown = function (input, options) {

--- a/lib/md-converters.js
+++ b/lib/md-converters.js
@@ -137,5 +137,15 @@ module.exports = [
     replacement: function (content, node) {
       return '\n\n' + this.outer(node, content) + '\n\n';
     }
+  },
+
+  // Anything else!
+  {
+    filter: function () {
+      return true;
+    },
+    replacement: function (content, node) {
+      return this.outer(node, content);
+    }
   }
 ];

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -75,7 +75,8 @@ test('anchors', function() {
   runTestCases([
     ['<a href="http://example.com/about">About us</a>', '[About us](http://example.com/about)', 'a'],
     ['<a href="http://example.com/about" title="About this company">About us</a>', '[About us](http://example.com/about "About this company")', 'a with title'],
-    ['<a id="donuts3">About us</a>', '<a id="donuts3">About us</a>', 'a with no src']
+    ['<a id="donuts3">About us</a>', '<a id="donuts3">About us</a>', 'a with no src'],
+    ['<a href="http://example.com/about"><span>About us</span></a>', '[<span>About us</span>](http://example.com/about)', 'with a span']
   ]);
 });
 


### PR DESCRIPTION
This prevents the DOM rebuild happening in `flankingWhitespace`, caused by setting `innerHTML`. This meant that `._replacement` was being lost in some cases, resulting in `undefined` output.

It adds a fallback converter, and tidies up `process`.

Fixes #92 
