### PR TITLE
Upgrade jsdom and other deps for iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "saucie": "0.1.3",
     "testem": "^0.8.2",
     "qunit": "^0.7.6",
-    "watchify": "^2.5.0"
+    "watchify": "^3.2.1"
   },
   "browser": {
     "jsdom": false
   },
   "dependencies": {
     "collapse-whitespace": "1.1.1",
-    "jsdom": "^3.1.2"
+    "jsdom": "^5.4.3"
   }
 }


### PR DESCRIPTION
Module would not install on iojs.  Upgraded jsdom@5.4.3 and watchify@3.2.1 so it will install.  I re-ran unit tests and things pass (iojs@2.0.1).  
