### PR TITLE
Add the option of disabling the default converters

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,10 @@ toMarkdown = function (input, options) {
       nodes = bfsOrder(clone),
       output;
 
-  converters = mdConverters.slice(0);
+  converters = [];
+  if (!options.noDefaultConverters) {
+    converters = mdConverters.slice(0);
+  }
   if (options.gfm) {
     converters = gfmConverters.concat(converters);
   }


### PR DESCRIPTION
This allows completely modifying the converter chain, making it possible to also work with / replace the default converters.

This allows code like

``` js
var toMarkdown = require('to-markdown');
var converters = require('to-markdown/lib/md-converters').slice(0, -1); // disable "everything"-converter
converters.push({
  filter: function() { return true; },
  replacement: function(content) { return content; }
}); // doesn't return tag anymore

toMarkdown("<unknown>HTML</unknown>", { noDefaultConverters: true, converters: converters });
```
