### PR TITLE
Fixes for IE8 (when run alongside an ES5-shim) and IE9 (HTML with doctype)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ $ bower install to-markdown
 <script>toMarkdown('<h1>Hello world!</h1>')</script>
 ```
 
+to-markdown works with most modern browsers (Chrome, firefox, IE, Opera). It should also work in IE8, and possibly earlier, with the inclusion of an ES5 shim (for example es5-shim 3.0.2 or later).
+
 ### Node.js
 
 Install the `to-markdown` module:

--- a/index.js
+++ b/index.js
@@ -77,10 +77,31 @@ function createHtmlParser() {
   var Parser = function () {};
 
   Parser.prototype.parseFromString = function (string) {
-    var newDoc = _document.implementation.createHTMLDocument('');
+    var newDoc;
+    if (_document.implementation.createHTMLDocument) {
+      newDoc = _document.implementation.createHTMLDocument('');
+    }
+    else {
+      // IE8 Workaround originally courtesy of https://github.com/Reffyy
+      newDoc = _document.createElement('body');
+      newDoc.documentElement = newDoc;
+      newDoc.body = newDoc;
+    }
 
     if (string.toLowerCase().indexOf('<!doctype') > -1) {
-      newDoc.documentElement.innerHTML = string;
+      try {
+        newDoc.documentElement.innerHTML = string;
+      }
+      catch (e) {
+        // IE9 doesn't allow setting innerHTML on the document, and because IE9 strips <body>
+        // tags going into another body/div we will attempt to extract the body manually
+        var matches = string.match(/<body([^>]*)?>[\s\S]*<\/body>/im);
+        if (matches) {
+          string = matches[0];
+        }
+        
+        newDoc.body.innerHTML = string;
+      }
     }
     else {
       newDoc.body.innerHTML = string;


### PR DESCRIPTION
The purpose of this pull request is primarily to fix an issue using this library in IE8. We had a fork with our changes, but I'm hoping it was worth tidying and looking to include into the main development branch (see: https://github.com/Reffyy/to-markdown/commit/f8f47c3599a96543bd91324ee27cdc34c6bfdeb5).

Rather than adding a dependency of the es5-shim library we use, I have instead looked to resolve issues we encountered while running alongside one. This way clients can include that dependency if IE8 compatibility is valuable, without any significant overhead to other clients (I hope). I have added to the readme a note about using es5-shim >= 3.0.2 (I tested various versions).

While implementing this fix I noticed an issue entering complete HTML (including doctype) in IE9 (emulated in IE11). It's not a use case I use, but I assume it's going to be in use by clients. I have attempted to also work around this issue, though there may well be improvements that can be done here.

All of my changes are at points where the code was previously failing (according to my testing), so I hope on that basis there should be no fallout to existing working functionality. Please correct me if not. The tests continue to pass as far as I can tell, though I cannot run them in IE8. I tried adding the shim with mixed success; I'm unfamiliar with QUnit.
