### PR TITLE
Move to JS dom no contextify.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "collapse-whitespace": "1.1.2",
-    "jsdom": "^3.1.2"
+    "jsdom-no-contextify": "^3.1.0"
   }
 }


### PR DESCRIPTION
Hi guys,

This PR aims to switch from jsdom to jsdom-no-contextify. jsdom version 4.4.x does not support Node 10, and jsdom 3.1.x has dependencies with contextify. Contextify has native build that requires Python.

As a result, I believe it makes sense to move to jsdom-no-contextify.

Alan
