### PR TITLE
Add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "collapse-whitespace": "1.1.2",
     "jsdom": "^6.5.1"
   },
-  "engines" : {
-    "node" : "^4"
-  }
+  "engines": {
+    "node": "^4"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Adds the license information to the `package.json`, so that it becomes visible and searchable in `npm`.
