### PR TITLE
Handle newlines inside strong/emphasis tags

### DIFF
--- a/lib/md-converters.js
+++ b/lib/md-converters.js
@@ -36,15 +36,19 @@ module.exports = [
 
   {
     filter: ['em', 'i'],
-    replacement: function (content) {
-      return '_' + content + '_';
+    replacement: function(content) {
+      return content.split(/\s*?(?:\r|\n)/).map(function(line) {
+        return line.trim().length ? '_' + line + '_' : line;
+      }).join("\n");
     }
   },
 
   {
     filter: ['strong', 'b'],
-    replacement: function (content) {
-      return '**' + content + '**';
+    replacement: function(content) {
+      return content.split(/\s*?(?:\r|\n)/).map(function(line) {
+        return line.trim().length ? '**' + line + '**' : line;
+      }).join("\n");
     }
   },
 

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -29,7 +29,9 @@ test('emphasis', function() {
     ['<strong>Hello world</strong>', '**Hello world**', 'strong'],
     ['<i>Hello world</i>', '_Hello world_', 'i'],
     ['<em>Hello world</em>', '_Hello world_', 'em'],
-    ['<em>Hello</em> <em>world</em>', '_Hello_ _world_', 'Multiple ems']
+    ['<em>Hello</em> <em>world</em>', '_Hello_ _world_', 'Multiple ems'],
+    ['<em>Hello <br><br> world</em>', '_Hello_\n\n_world_', 'em with two newlines'],
+    ['<strong>Hello <br><br> world<strong>', '**Hello**\n\n**world**', 'strong with two newlines'],
   ]);
 });
 


### PR DESCRIPTION
Previously the following markup:

``` html
<em>Hello <br><br> world</em>
```

would get converted into the markdown:

```
_hello

world_
```

which is incorrect. Both lines should be surrounded with underscores. This pull request splits `em`, `i,`strong`, and`b` tags into lines and surrounds each line with the appropriate markdown
