### PR TITLE
Don't crash on malformed documents

### DIFF
--- a/dist/to-markdown.js
+++ b/dist/to-markdown.js
@@ -13,13 +13,8 @@ var toMarkdown;
 var converters;
 var mdConverters = require('./lib/md-converters');
 var gfmConverters = require('./lib/gfm-converters');
+var HtmlParser = require('./lib/html-parser');
 var collapse = require('collapse-whitespace');
-
-/*
- * Set up window and document for Node.js
- */
-
-var _window = (typeof window !== 'undefined' ? window : this);
 
 /*
  * Utilities
@@ -49,75 +44,6 @@ var voids = [
 function isVoid(node) {
   return voids.indexOf(node.nodeName.toLowerCase()) !== -1;
 }
-
-/*
- * Parsing HTML strings
- */
-
-function canParseHtml() {
-  var Parser = _window.DOMParser, canParse = false;
-
-  // Adapted from https://gist.github.com/1129031
-  // Firefox/Opera/IE throw errors on unsupported types
-  try {
-    // WebKit returns null on unsupported types
-    if (new Parser().parseFromString('', 'text/html')) {
-      canParse = true;
-    }
-  } catch (e) {}
-  return canParse;
-}
-
-function createHtmlParser() {
-  var Parser = function () {};
-
-  if (typeof document === 'undefined') {
-    var jsdom = require('jsdom');
-    Parser.prototype.parseFromString = function (string) {
-      return jsdom.jsdom(string, {
-        features: {
-          FetchExternalResources: [],
-          ProcessExternalResources: false
-        }
-      });
-    };
-  } else {
-    var useActiveX = false;
-    try {
-      var testDoc = document.implementation.createHTMLDocument('');
-      testDoc.open();
-    } catch (e) {
-      if (window.ActiveXObject) {
-        // IE9
-        useActiveX = true;
-      } // otherwise this will fail - badly (shouldn't happen in any browser though)
-    }
-
-    if (!useActiveX) {
-      Parser.prototype.parseFromString = function (string) {
-        // this is the most correct parsing method
-        var newDoc = document.implementation.createHTMLDocument('');
-        newDoc.open();
-        newDoc.write(string);
-        newDoc.close();
-        return newDoc;
-      };
-    } else {
-      Parser.prototype.parseFromString = function (string) {
-        // correct fallback for IE9
-        var newDoc = new ActiveXObject('htmlfile');
-        newDoc.designMode = "on"; // this disables on-page scripts... yes - I know
-        newDoc.open();
-        newDoc.write(string);
-        newDoc.close();
-        return newDoc;
-      };
-    }
-  }
-  return Parser;
-}
-
-var HtmlParser = canParseHtml() ? _window.DOMParser : createHtmlParser();
 
 function htmlToDom(string) {
   var tree = new HtmlParser().parseFromString(string, 'text/html');
@@ -308,7 +234,7 @@ toMarkdown.outer = outer;
 
 module.exports = toMarkdown;
 
-},{"./lib/gfm-converters":2,"./lib/md-converters":3,"collapse-whitespace":6,"jsdom":5}],2:[function(require,module,exports){
+},{"./lib/gfm-converters":2,"./lib/html-parser":3,"./lib/md-converters":4,"collapse-whitespace":7}],2:[function(require,module,exports){
 'use strict';
 
 function cell(content, node) {
@@ -421,6 +347,84 @@ module.exports = [
 ];
 
 },{}],3:[function(require,module,exports){
+/*
+ * Set up window for Node.js
+ */
+
+var _window = (typeof window !== 'undefined' ? window : this);
+
+/*
+ * Parsing HTML strings
+ */
+
+function canParseHtmlNatively () {
+  var Parser = _window.DOMParser
+  var canParse = false;
+
+  // Adapted from https://gist.github.com/1129031
+  // Firefox/Opera/IE throw errors on unsupported types
+  try {
+    // WebKit returns null on unsupported types
+    if (new Parser().parseFromString('', 'text/html')) {
+      canParse = true;
+    }
+  } catch (e) {}
+
+  return canParse;
+}
+
+function createHtmlParser () {
+  var Parser = function () {};
+  
+  // For Node.js environments
+  if (typeof document === 'undefined') {
+    var jsdom = require('jsdom');
+    Parser.prototype.parseFromString = function (string) {
+      return jsdom.jsdom(string, {
+        features: {
+          FetchExternalResources: [],
+          ProcessExternalResources: false
+        }
+      });
+    };
+  } else {
+    if (!shouldUseActiveX()) {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = document.implementation.createHTMLDocument('');
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    } else {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = new ActiveXObject('htmlfile');
+        doc.designMode = 'on'; // disable on-page scripts
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    }
+  }
+  return Parser;
+}
+
+function shouldUseActiveX () {
+  var useActiveX = false;
+
+  try {
+    document.implementation.createHTMLDocument('').open();
+  } catch (e) {
+    if (window.ActiveXObject) useActiveX = true;
+  }
+
+  return useActiveX;
+}
+
+module.exports = canParseHtmlNatively() ? _window.DOMParser : createHtmlParser()
+
+},{"jsdom":6}],4:[function(require,module,exports){
 'use strict';
 
 module.exports = [
@@ -572,7 +576,7 @@ module.exports = [
     }
   }
 ];
-},{}],4:[function(require,module,exports){
+},{}],5:[function(require,module,exports){
 /**
  * This file automatically generated from `build.js`.
  * Do not manually edit.
@@ -616,9 +620,9 @@ module.exports = [
   "video"
 ];
 
-},{}],5:[function(require,module,exports){
-
 },{}],6:[function(require,module,exports){
+
+},{}],7:[function(require,module,exports){
 'use strict';
 
 var voidElements = require('void-elements');
@@ -756,7 +760,7 @@ function next(prev, current) {
 
 module.exports = collapseWhitespace;
 
-},{"block-elements":4,"void-elements":7}],7:[function(require,module,exports){
+},{"block-elements":5,"void-elements":8}],8:[function(require,module,exports){
 /**
  * This file automatically generated from `pre-publish.js`.
  * Do not manually edit.

--- a/dist/to-markdown.js
+++ b/dist/to-markdown.js
@@ -19,13 +19,7 @@ var collapse = require('collapse-whitespace');
  * Set up window and document for Node.js
  */
 
-var _window = (typeof window !== 'undefined' ? window : this), _document;
-if (typeof document === 'undefined') {
-  _document = require('jsdom').jsdom();
-}
-else {
-  _document = document;
-}
+var _window = (typeof window !== 'undefined' ? window : this);
 
 /*
  * Utilities
@@ -77,17 +71,49 @@ function canParseHtml() {
 function createHtmlParser() {
   var Parser = function () {};
 
-  Parser.prototype.parseFromString = function (string) {
-    var newDoc = _document.implementation.createHTMLDocument('');
+  if (typeof document === 'undefined') {
+    var jsdom = require('jsdom');
+    Parser.prototype.parseFromString = function (string) {
+      return jsdom.jsdom(string, {
+        features: {
+          FetchExternalResources: [],
+          ProcessExternalResources: false
+        }
+      });
+    };
+  } else {
+    var useActiveX = false;
+    try {
+      var testDoc = document.implementation.createHTMLDocument('');
+      testDoc.open();
+    } catch (e) {
+      if (window.ActiveXObject) {
+        // IE9
+        useActiveX = true;
+      } // otherwise this will fail - badly (shouldn't happen in any browser though)
+    }
 
-    if (string.toLowerCase().indexOf('<!doctype') > -1) {
-      newDoc.documentElement.innerHTML = string;
+    if (!useActiveX) {
+      Parser.prototype.parseFromString = function (string) {
+        // this is the most correct parsing method
+        var newDoc = document.implementation.createHTMLDocument('');
+        newDoc.open();
+        newDoc.write(string);
+        newDoc.close();
+        return newDoc;
+      };
+    } else {
+      Parser.prototype.parseFromString = function (string) {
+        // correct fallback for IE9
+        var newDoc = new ActiveXObject('htmlfile');
+        newDoc.designMode = "on"; // this disables on-page scripts... yes - I know
+        newDoc.open();
+        newDoc.write(string);
+        newDoc.close();
+        return newDoc;
+      };
     }
-    else {
-      newDoc.body.innerHTML = string;
-    }
-    return newDoc;
-  };
+  }
   return Parser;
 }
 
@@ -95,7 +121,7 @@ var HtmlParser = canParseHtml() ? _window.DOMParser : createHtmlParser();
 
 function htmlToDom(string) {
   var tree = new HtmlParser().parseFromString(string, 'text/html');
-  collapse(tree, isBlock);
+  collapse(tree.documentElement, isBlock);
   return tree;
 }
 
@@ -282,7 +308,7 @@ toMarkdown.outer = outer;
 
 module.exports = toMarkdown;
 
-},{"./lib/gfm-converters":2,"./lib/md-converters":3,"collapse-whitespace":4,"jsdom":7}],2:[function(require,module,exports){
+},{"./lib/gfm-converters":2,"./lib/md-converters":3,"collapse-whitespace":6,"jsdom":5}],2:[function(require,module,exports){
 'use strict';
 
 function cell(content, node) {
@@ -547,6 +573,52 @@ module.exports = [
   }
 ];
 },{}],4:[function(require,module,exports){
+/**
+ * This file automatically generated from `build.js`.
+ * Do not manually edit.
+ */
+
+module.exports = [
+  "address",
+  "article",
+  "aside",
+  "audio",
+  "blockquote",
+  "canvas",
+  "dd",
+  "div",
+  "dl",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "hgroup",
+  "hr",
+  "main",
+  "nav",
+  "noscript",
+  "ol",
+  "output",
+  "p",
+  "pre",
+  "section",
+  "table",
+  "tfoot",
+  "ul",
+  "video"
+];
+
+},{}],5:[function(require,module,exports){
+
+},{}],6:[function(require,module,exports){
 'use strict';
 
 var voidElements = require('void-elements');
@@ -684,51 +756,7 @@ function next(prev, current) {
 
 module.exports = collapseWhitespace;
 
-},{"block-elements":5,"void-elements":6}],5:[function(require,module,exports){
-/**
- * This file automatically generated from `build.js`.
- * Do not manually edit.
- */
-
-module.exports = [
-  "address",
-  "article",
-  "aside",
-  "audio",
-  "blockquote",
-  "canvas",
-  "dd",
-  "div",
-  "dl",
-  "fieldset",
-  "figcaption",
-  "figure",
-  "footer",
-  "form",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "header",
-  "hgroup",
-  "hr",
-  "main",
-  "nav",
-  "noscript",
-  "ol",
-  "output",
-  "p",
-  "pre",
-  "section",
-  "table",
-  "tfoot",
-  "ul",
-  "video"
-];
-
-},{}],6:[function(require,module,exports){
+},{"block-elements":4,"void-elements":7}],7:[function(require,module,exports){
 /**
  * This file automatically generated from `pre-publish.js`.
  * Do not manually edit.
@@ -752,8 +780,6 @@ module.exports = {
   "track": true,
   "wbr": true
 };
-
-},{}],7:[function(require,module,exports){
 
 },{}]},{},[1])(1)
 });

--- a/lib/html-parser.js
+++ b/lib/html-parser.js
@@ -1,0 +1,76 @@
+/*
+ * Set up window for Node.js
+ */
+
+var _window = (typeof window !== 'undefined' ? window : this);
+
+/*
+ * Parsing HTML strings
+ */
+
+function canParseHtmlNatively () {
+  var Parser = _window.DOMParser
+  var canParse = false;
+
+  // Adapted from https://gist.github.com/1129031
+  // Firefox/Opera/IE throw errors on unsupported types
+  try {
+    // WebKit returns null on unsupported types
+    if (new Parser().parseFromString('', 'text/html')) {
+      canParse = true;
+    }
+  } catch (e) {}
+
+  return canParse;
+}
+
+function createHtmlParser () {
+  var Parser = function () {};
+  
+  // For Node.js environments
+  if (typeof document === 'undefined') {
+    var jsdom = require('jsdom');
+    Parser.prototype.parseFromString = function (string) {
+      return jsdom.jsdom(string, {
+        features: {
+          FetchExternalResources: [],
+          ProcessExternalResources: false
+        }
+      });
+    };
+  } else {
+    if (!shouldUseActiveX()) {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = document.implementation.createHTMLDocument('');
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    } else {
+      Parser.prototype.parseFromString = function (string) {
+        var doc = new ActiveXObject('htmlfile');
+        doc.designMode = 'on'; // disable on-page scripts
+        doc.open();
+        doc.write(string);
+        doc.close();
+        return doc;
+      };
+    }
+  }
+  return Parser;
+}
+
+function shouldUseActiveX () {
+  var useActiveX = false;
+
+  try {
+    document.implementation.createHTMLDocument('').open();
+  } catch (e) {
+    if (window.ActiveXObject) useActiveX = true;
+  }
+
+  return useActiveX;
+}
+
+module.exports = canParseHtmlNatively() ? _window.DOMParser : createHtmlParser()

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "collapse-whitespace": "1.1.2",
-    "jsdom": "^6.5.1"
+    "jsdom": "^8.1.0"
   },
   "engines": {
     "node": "^4"

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -436,3 +436,9 @@ asyncTest('img[onerror]', 1, function () {
   start();
   equal(toMarkdown('>\'>"><img src=x onerror="(function () { ok(true); })()">'), '>\'>">![](x)', 'We expect img[onerror] functions not to run');
 });
+
+test('malformed documents', function() {
+  expect(0); // just make sure to-markdown doesn't crash
+  var html = '<HTML><head></head><BODY><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><body onload=alert(document.cookie);></body></html>';
+  toMarkdown(html);
+});


### PR DESCRIPTION
This is actually a bug with inline event handles in jsdom, but it's easily fixable here and also makes to-markdown rely on much better supported APIs than before.
