### PR TITLE
Bug with Whitespace trimming for bold links.

### DIFF
--- a/dist/to-markdown.js
+++ b/dist/to-markdown.js
@@ -130,13 +130,13 @@ function isFlankedByWhitespace (side, node) {
   return isFlanked
 }
 
-function flankingWhitespace (node) {
+function flankingWhitespace (node, content) {
   var leading = ''
   var trailing = ''
 
   if (!isBlock(node)) {
-    var hasLeading = /^[ \r\n\t]/.test(node.innerHTML)
-    var hasTrailing = /[ \r\n\t]$/.test(node.innerHTML)
+    var hasLeading = /^[ \r\n\t]/.test(content)
+    var hasTrailing = /[ \r\n\t]$/.test(content)
 
     if (hasLeading && !isFlankedByWhitespace('left', node)) {
       leading = ' '
@@ -174,7 +174,7 @@ function process (node) {
         )
       }
 
-      var whitespace = flankingWhitespace(node)
+      var whitespace = flankingWhitespace(node, content)
 
       if (whitespace.leading || whitespace.trailing) {
         content = content.trim()

--- a/index.js
+++ b/index.js
@@ -129,13 +129,13 @@ function isFlankedByWhitespace (side, node) {
   return isFlanked
 }
 
-function flankingWhitespace (node) {
+function flankingWhitespace (node, content) {
   var leading = ''
   var trailing = ''
 
   if (!isBlock(node)) {
-    var hasLeading = /^[ \r\n\t]/.test(node.innerHTML)
-    var hasTrailing = /[ \r\n\t]$/.test(node.innerHTML)
+    var hasLeading = /^[ \r\n\t]/.test(content)
+    var hasTrailing = /[ \r\n\t]$/.test(content)
 
     if (hasLeading && !isFlankedByWhitespace('left', node)) {
       leading = ' '
@@ -173,7 +173,7 @@ function process (node) {
         )
       }
 
-      var whitespace = flankingWhitespace(node)
+      var whitespace = flankingWhitespace(node, content)
 
       if (whitespace.leading || whitespace.trailing) {
         content = content.trim()

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -380,6 +380,11 @@ test('leading/trailing whitespace', function () {
       '<h1><img src="image.png"> Hello world.</h1>',
       '# ![](image.png) Hello world.',
       'Whitespace and void elements'
+    ],
+    [
+      'Hello <strong><a href="https://www.google.com">Hello </a></strong>Hello',
+      'Hello **[Hello](https://www.google.com)** Hello',
+      'Whitespace in bold links.'
     ]
   ])
 })


### PR DESCRIPTION
Hi, I've noticed a bug in how to-markdown handles whitespace trimming for links.

The following html 

```
Hello <strong><a href="https://www.google.com">Hello </a></strong>Hello
```

Would be converted into markdown as 

```
Hello **[Hello](https://www.google.com) **Hello
```

Which results in incorrect markup when rendered using [markdown-it](https://github.com/markdown-it/markdown-it)

This pull request makes it so that the above html is converted to 

```
Hello **[Hello](https://www.google.com)** Hello
```

Which renders correctly as a bold link.
