### PR TITLE
Add pandoc converters

### DIFF
--- a/dist/to-markdown.js
+++ b/dist/to-markdown.js
@@ -13,6 +13,7 @@ var toMarkdown
 var converters
 var mdConverters = require('./lib/md-converters')
 var gfmConverters = require('./lib/gfm-converters')
+var pandocConverters = require('./lib/pandoc-converters')
 var HtmlParser = require('./lib/html-parser')
 var collapse = require('collapse-whitespace')
 
@@ -208,6 +209,10 @@ toMarkdown = function (input, options) {
     converters = gfmConverters.concat(converters)
   }
 
+  if (options.pandoc) {
+    converters = pandocConverters.concat(converters)
+  }
+
   if (options.converters) {
     converters = options.converters.concat(converters)
   }
@@ -229,7 +234,7 @@ toMarkdown.outer = outer
 
 module.exports = toMarkdown
 
-},{"./lib/gfm-converters":2,"./lib/html-parser":3,"./lib/md-converters":4,"collapse-whitespace":7}],2:[function(require,module,exports){
+},{"./lib/gfm-converters":2,"./lib/html-parser":3,"./lib/md-converters":4,"collapse-whitespace":7,"./lib/pandoc-converters":8}],2:[function(require,module,exports){
 'use strict'
 
 function cell (content, node) {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var toMarkdown
 var converters
 var mdConverters = require('./lib/md-converters')
 var gfmConverters = require('./lib/gfm-converters')
+var pandocConverters = require('./lib/pandoc-converters')
 var HtmlParser = require('./lib/html-parser')
 var collapse = require('collapse-whitespace')
 
@@ -205,6 +206,10 @@ toMarkdown = function (input, options) {
   converters = mdConverters.slice(0)
   if (options.gfm) {
     converters = gfmConverters.concat(converters)
+  }
+
+  if (options.pandoc) {
+    converters = pandocConverters.concat(converters)
   }
 
   if (options.converters) {

--- a/lib/pandoc-converters.js
+++ b/lib/pandoc-converters.js
@@ -1,0 +1,106 @@
+'use strict'
+
+module.exports = [
+  {
+    filter: 'h1',
+    replacement: function (content, node) {
+      var underline = Array(content.length + 1).join('=')
+      return '\n\n' + content + '\n' + underline + '\n\n'
+    }
+  },
+
+  {
+    filter: 'h2',
+    replacement: function (content, node) {
+      var underline = Array(content.length + 1).join('-')
+      return '\n\n' + content + '\n' + underline + '\n\n'
+    }
+  },
+
+  {
+    filter: 'sup',
+    replacement: function (content) {
+      return '^' + content + '^'
+    }
+  },
+
+  {
+    filter: 'sub',
+    replacement: function (content) {
+      return '~' + content + '~'
+    }
+  },
+
+  {
+    filter: 'br',
+    replacement: function () {
+      return '\\\n'
+    }
+  },
+
+  {
+    filter: 'hr',
+    replacement: function () {
+      return '\n\n* * * * *\n\n'
+    }
+  },
+
+  {
+    filter: ['em', 'i'],
+    replacement: function (content) {
+      return '*' + content + '*'
+    }
+  },
+
+  {
+    filter: function (node) {
+      var hasSiblings = node.previousSibling || node.nextSibling
+      var isCodeBlock = node.parentNode.nodeName === 'PRE' && !hasSiblings
+      var isCodeElem = node.nodeName === 'CODE' ||
+          node.nodeName === 'KBD'  ||
+          node.nodeName === 'SAMP' ||
+          node.nodeName === 'TT'
+
+      return isCodeElem && !isCodeBlock
+    },
+    replacement: function (content) {
+      return '`' + content + '`'
+    }
+  },
+
+  {
+    filter: function (node) {
+      return node.nodeName === 'A' && node.getAttribute('href')
+    },
+    replacement: function (content, node) {
+      var url = node.getAttribute('href')
+      var titlePart = node.title ? ' "' + node.title + '"' : ''
+      if (content === url) {
+        return '<' + url + '>'
+      } else if (url.match('mailto:' + content)) {
+        return '<' + content + '>'
+      } else {
+        return '[' + content + '](' + url + titlePart + ')'
+      }
+    }
+  },
+
+  {
+    filter: 'li',
+    replacement: function (content, node) {
+      content = content.replace(/^\s+/, '').replace(/\n/gm, '\n    ')
+      var prefix = '-   '
+      var parent = node.parentNode
+
+      if (/ol/i.test(parent.nodeName)) {
+        var index = Array.prototype.indexOf.call(parent.children, node) + 1
+        prefix = index + '. '
+        while (prefix.length < 4) {
+          prefix += ' '
+        }
+      }
+
+      return prefix + content
+    }
+  }
+]

--- a/lib/pandoc-converters.js
+++ b/lib/pandoc-converters.js
@@ -57,7 +57,7 @@ module.exports = [
       var hasSiblings = node.previousSibling || node.nextSibling
       var isCodeBlock = node.parentNode.nodeName === 'PRE' && !hasSiblings
       var isCodeElem = node.nodeName === 'CODE' ||
-          node.nodeName === 'KBD'  ||
+          node.nodeName === 'KBD' ||
           node.nodeName === 'SAMP' ||
           node.nodeName === 'TT'
 


### PR DESCRIPTION
Add an option for the Markdown style used by pandoc, detailed at:
http://pandoc.org/README.html#pandocs-markdown

H1 and H2 headers are rendered with underlines:

```
H1 Header
=========

H2 Header
---------
```

Superscripts and subscripts are supported:

```
^Superscript^

~Subscript~
```

Hard line breaks are created by a backslash followed by a newline:

```
A line\
Another line
```

Horizontal rules are rendered as five asterisks:

```
* * * * *
```

Asterisks are also used for emphasis:

```
This text is *emphasized*.
```

CODE, KBD, SAMP and TT elements are rendered as inline code blocks:

```
Press `Ctrl+V` to paste.
```

URL links are enclosed in pointy brackets:

```
<http://www.example.org/>
```

Unordered lists use hyphens as their bullet and adhere to the four-space rule:

```
-   Item one
-   Item two
```

Ordered lists also adhere to this rule, whether the number consists of one or two digits:

```
1.  Item one
2.  Item two
...
10. Item ten
11. Item eleven
```

The pandoc style is provided as a boolean option.

Some of the converters could perhaps be merged into the default style. I leave that consideration to you. :)
