### PR TITLE
Allow node versions greater than 4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "watchify": "^2.5.0"
   },
   "engines": {
-    "node": "^4"
+    "node": ">=4"
   },
   "keywords": [
     "markdown"


### PR DESCRIPTION
This fixes the node engine version number, it used to allow only node v4 versions.
Now it allows for node v4 or greater.

Resolves https://github.com/domchristie/to-markdown/issues/166
