### PR TITLE
Don't attempt to parse empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ toMarkdown = function (input, options) {
   }
 
   if (input === '') {
-    return '';
+    return ''
   }
 
   // Escape potential ol triggers

--- a/index.js
+++ b/index.js
@@ -195,6 +195,10 @@ toMarkdown = function (input, options) {
     throw new TypeError(input + ' is not a string')
   }
 
+  if (input === '') {
+    return '';
+  }
+
   // Escape potential ol triggers
   input = input.replace(/(\d+)\. /g, '$1\\. ')
 

--- a/test/to-markdown-test.js
+++ b/test/to-markdown-test.js
@@ -449,3 +449,9 @@ test('malformed documents', function () {
   var html = '<HTML><head></head><BODY><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><body onload=alert(document.cookie);></body></html>'
   toMarkdown(html)
 })
+
+test('empty string', function () {
+  runTestCases([
+    ['', '']
+  ])
+})


### PR DESCRIPTION
This has two benefits:
1. Slight performance improvements from not running processing operations on an empty string
2. Fixes a compatibility issue with `DOMParser` in Internet Explorer 11 (and possibly other IE versions). Example:
   
   ``` js
   // In Chrome
   new DOMParser().parseFromString('', 'text/html').documentElement
   // => <html><head></head><body></body></html>
   
   // In IE11
   new DOMParser().parseFromString('', 'text/html').documentElement
   // => null
   ```
   
   This inconsistency causes an error [in `htmlToDom`](https://github.com/domchristie/to-markdown/blob/master/index.js#L43-L47) when the `documentElement` is passed to `collapse`, which [expects a valid node](https://github.com/lucthev/collapse-whitespace/blob/master/src/whitespace.js#L44).
