### PR TITLE
add support for markdown-it gfm

### DIFF
--- a/lib/gfm-converters.js
+++ b/lib/gfm-converters.js
@@ -7,7 +7,7 @@ function cell (content, node) {
   return prefix + content + ' |'
 }
 
-var highlightRegEx = /highlight highlight-(\S+)/
+var highlightRegEx = /(?:highlight|language)-(\S+)/
 
 module.exports = [
   {
@@ -73,7 +73,21 @@ module.exports = [
     }
   },
 
-  // Fenced code blocks
+  // Syntax-highlighted code blocks (markdown-it style)
+  {
+    filter: function (node) {
+      return node.nodeName === 'PRE' &&
+      node.firstChild &&
+      node.firstChild.nodeName === 'CODE' &&
+      highlightRegEx.test(node.firstChild.className)
+    },
+    replacement: function (content, node) {
+      var language = node.firstChild.className.match(highlightRegEx)[1]
+      return '\n\n```' + language + '\n' + node.firstChild.textContent.trim() + '\n```\n\n'
+    }
+  },
+
+  // Language-agnostic fence code blocks
   {
     filter: function (node) {
       return node.nodeName === 'PRE' &&

--- a/lib/gfm-converters.js
+++ b/lib/gfm-converters.js
@@ -7,7 +7,7 @@ function cell (content, node) {
   return prefix + content + ' |'
 }
 
-var highlightRegEx = /(?:highlight|language)-(\S+)/
+var highlightRegEx = /(?:highlight|language|lang)-(\S+)/
 
 module.exports = [
   {

--- a/test/gfm-test.js
+++ b/test/gfm-test.js
@@ -208,9 +208,16 @@ test('syntax highlighting', function () {
         '        <td>Foo</td>',
         '    </tr>',
         '</table>',
-        '```'].join('\n'),
+        '```'].join('\n')
+    ]
+  ])
+})
 
-      'HTML'
+test('syntax highlighting (markdown-it style)', function () {
+  runGfmTestCases([
+    [
+      '<pre><code class="language-javascript">alert(\'hello\')</code></pre>',
+      '```javascript\nalert(\'hello\')\n```'
     ]
   ])
 })


### PR DESCRIPTION
Hi @domchristie!

This PR adds support for generating GitHub Flavored Markdown (GFM) fenced code blocks from HTML that was created using the [markdown-it](https://github.com/markdown-it/markdown-it) parser. The HTML generated by markdown-it for a fenced block looks like this:

```html
<pre><code class="language-javascript">alert('hello, world')</code></pre>
```

This is slightly different from the existing expected structure, so I've added a new converter for it.
I also updated the `highlightRegEx` pattern to work for both the existing and new use case.

cc @puzrin, maintainer of markdown-it and all-around nice guy. :)
