### PR TITLE
Add option to disable escaping ol triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ to-markdown has beta support for GitHub flavored markdown (GFM). Set the `gfm` o
 toMarkdown('<del>Hello world!</del>', { gfm: true });
 ```
 
+### `escapeOrderedList` (boolean)
+
+By default, to-markdown will escape plain text numbered lists. This is in an attempt to have [lossless conversion between HTML and markdown](https://github.com/domchristie/to-markdown/issues/81#issuecomment-96992781). For example, `1. Item A` will become `1\. Item A` when escaped. Set `escapeOrderedList` to false to disable this functionality:
+
+```js
+toMarkdown('<b>1. Item A</b>', { escapeOrderedList: false });
+```
+
 ## Methods
 
 The following methods can be called on the `toMarkdown` object.

--- a/index.js
+++ b/index.js
@@ -191,6 +191,11 @@ function process (node) {
 toMarkdown = function (input, options) {
   options = options || {}
 
+  // Default escaping ol triggers to true
+  if (typeof options.escapeOrderedList !== 'boolean') {
+    options.escapeOrderedList = true
+  }
+
   if (typeof input !== 'string') {
     throw new TypeError(input + ' is not a string')
   }
@@ -200,7 +205,9 @@ toMarkdown = function (input, options) {
   }
 
   // Escape potential ol triggers
-  input = input.replace(/(\d+)\. /g, '$1\\. ')
+  if (options.escapeOrderedList) {
+    input = input.replace(/(\d+)\. /g, '$1\\. ')
+  }
 
   var clone = htmlToDom(input).body
   var nodes = bfsOrder(clone)


### PR DESCRIPTION
Hi Dom,

### Reason to add feature

Similar to other people in #81, I needed to disable the feature to escape ordered lists. I noticed that there are quite a few people also asking for this ability, so I thought I would put it behind an option flag. I understand `turndown` solves this issue as well and I'm looking forward to using it once merged into master!

### How it works

Users must opt-in to disabling the escaping of ordered list. I believe this stays true to your belief to [preserve the integrity of the HTML](https://github.com/domchristie/to-markdown/issues/81#issuecomment-96992781) and be as lossless as possible.

```
toMarkdown('<b>1. Item</b>', { escapeOrderedList: false });
```

### Included in the Pull Request

- Added `options.escapeOrderedList` with default to `true`
- Added `README.md` documentation

### Considerations before merging

- Tests pass, but I did not add a test for the new option
  - Passing tests proves that the default behaviour is to continue to escape ol lists
  - No tests were added for other options, which is why I did not add any this option
- `escapeOrderedList` may not match the library's naming convention
  - `lossless: <boolean>` may be a better choice but I felt it was too broad

I'm happy to make any changes that you require and, if you choose to not merge this (adding yet another option to the library), then I totally understand.

Cheers,
Michael