### PR TITLE
Only add a trailing line break for indented code blocks

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -115,7 +115,8 @@ rules.fencedCodeBlock = {
     return (
       '\n\n' + options.fence + language + '\n' +
       node.firstChild.textContent +
-      '\n' + options.fence + '\n\n'
+      (options.codeBlockStyle === 'indented' ? '\n' : '') + 
+      options.fence + '\n\n'
     )
   }
 }


### PR DESCRIPTION
The currently implementation creates an extra unnecessary line break when the `codeBlockStyle` is `"fenced"`.