### PR TITLE
Remove extra trailing line breaks from fenced code blocks

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -114,7 +114,7 @@ rules.fencedCodeBlock = {
 
     return (
       '\n\n' + options.fence + language + '\n' +
-      node.firstChild.textContent +
+      node.firstChild.textContent.replace(/^\s+|\s+$/g, '') +
       '\n' + options.fence + '\n\n'
     )
   }


### PR DESCRIPTION
Right now fenced code blocks are produced with a trailing inner line break, such as:

```js
const foo = 'bar'


```

This change just removes trailing inner line breaks so the output will look as expected:
```js
const foo = 'bar'
```