### PR TITLE
Add the option to disable escaping markdown characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var markdown = turndownService.turndown(document.getElementById('content'))
 
 ## Options
 
-Options can be passed in to the constructor on instantiation.
+Options can be passed into the constructor on instantiation.
 
 | Option                | Valid values  | Default |
 | :-------------------- | :------------ | :------ |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options can be passed in to the constructor on instantiation.
 | `strongDelimiter`     | `**` or `__` | `**` |
 | `linkStyle`           | `inlined` or `referenced` | `inlined` |
 | `linkReferenceStyle`  | `full`, `collapsed`, or `shortcut` | `full` |
+| `escapeMarkdown`      | `true` or `false` | `true` |
 
 ### Advanced Options
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -22,6 +22,7 @@ export default function TurndownService (options) {
     linkStyle: 'inlined',
     linkReferenceStyle: 'full',
     br: '  ',
+    escapeMarkdown: true,
     blankReplacement: function (content, node) {
       return node.isBlock ? '\n\n' : ''
     },
@@ -186,7 +187,9 @@ function process (parentNode) {
 
     var replacement = ''
     if (node.nodeType === 3) {
-      replacement = node.isCode ? node.nodeValue : self.escape(node.nodeValue)
+      replacement = (node.isCode || !self.options.escapeMarkdown) ?
+        node.nodeValue :
+        self.escape(node.nodeValue)
     } else if (node.nodeType === 1) {
       replacement = replacementForNode.call(self, node)
     }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -187,9 +187,9 @@ function process (parentNode) {
 
     var replacement = ''
     if (node.nodeType === 3) {
-      replacement = (node.isCode || !self.options.escapeMarkdown) ?
-        node.nodeValue :
-        self.escape(node.nodeValue)
+      replacement = (node.isCode || !self.options.escapeMarkdown)
+        ? node.nodeValue
+        : self.escape(node.nodeValue)
     } else if (node.nodeType === 1) {
       replacement = replacementForNode.call(self, node)
     }

--- a/test/turndown-test.js
+++ b/test/turndown-test.js
@@ -168,3 +168,27 @@ test('remove elements are overridden by keep', function (t) {
     'Hello <del>world</del><ins>World</ins>'
   )
 })
+
+test('escape is not called when escapeMarkdown is false', function (t) {
+  t.plan(1)
+  var escapeCalled = false
+  var turndownService = new TurndownService({escapeMarkdown: false})
+  turndownService.escape = function (string) {
+    escapeCalled = true
+    return string;
+  }
+  turndownService.turndown('<p>Paragraph. *Italic*.</p>')
+  if (escapeCalled) {
+    t.fail('escape was called even though escapeMarkdown was false')
+  } else {
+    t.pass('escape was not called')
+  }
+})
+
+test('escapeMarkdown disables escaping when false', function (t) {
+  t.plan(1)
+  var turndownService = new TurndownService({escapeMarkdown: false})
+  t.equal(turndownService.turndown(
+    '<p>Paragraph. *Italic*, **bold**, and `monospace`. Itemized [link](http://www.example.com)</p>'),
+    'Paragraph. *Italic*, **bold**, and `monospace`. Itemized [link](http://www.example.com)')
+})


### PR DESCRIPTION
This adds an option that can be passed to the constructor to disable the escaping of markdown characters.  Obviously this is not the desired behavior in most cases, so the default is set to escape just like before.

We need this for a case where users are writing Markdown in a HTML WYSIWYG editor. This is later used in a different system that supports Markdown. We convert the HTML to Markdown using turndown to preserve formatting but we also need the Markdown that was written in the HTML editor to be rendered as Markdown. :cry: 

I also added the new option to the readme and wrote some tests for it.