### PR TITLE
Handle <br>s inside code blocks.

### DIFF
--- a/src/collapse-whitespace.js
+++ b/src/collapse-whitespace.js
@@ -26,7 +26,7 @@
  */
 
 /**
- * collapseWhitespace(options) removes extraneous whitespace from an the given element.
+ * collapseWhitespace(options) removes extraneous whitespace from the given element.
  *
  * @param {Object} options
  */

--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -10,10 +10,22 @@ rules.paragraph = {
   }
 }
 
+function isInPreformattedText (node) {
+  for (; node; node = node.parentNode) {
+    if (node.nodeName === 'PRE' || node.nodeName === 'CODE') {
+      return true
+    }
+  }
+  return false
+}
+
 rules.lineBreak = {
   filter: 'br',
 
   replacement: function (content, node, options) {
+    if (isInPreformattedText(node)) {
+      return '\n'
+    }
     return options.br + '\n'
   }
 }
@@ -92,7 +104,7 @@ rules.indentedCodeBlock = {
   replacement: function (content, node, options) {
     return (
       '\n\n    ' +
-      node.firstChild.textContent.replace(/\n/g, '\n    ') +
+      content.replace(/\n/g, '\n    ') +
       '\n\n'
     )
   }
@@ -114,7 +126,7 @@ rules.fencedCodeBlock = {
 
     return (
       '\n\n' + options.fence + language + '\n' +
-      node.firstChild.textContent +
+      content +
       '\n' + options.fence + '\n\n'
     )
   }

--- a/test/turndown-test.js
+++ b/test/turndown-test.js
@@ -168,3 +168,12 @@ test('remove elements are overridden by keep', function (t) {
     'Hello <del>world</del><ins>World</ins>'
   )
 })
+
+test('code blocks with html', function(t) {
+  t.plan(1);
+  var turndownService = new TurndownService({ codeBlockStyle: 'fenced' })
+  t.equal(turndownService.turndown(
+    '<pre><code>foo<br>bar<br>world</br>baz</code></pre>'),
+    '```\nfoo\nbar\nworld\nbaz\n```'
+  )
+});


### PR DESCRIPTION
Context: I'm processing some exported code which has code that looks like:

`<pre><code>foo<br>bar<br>baz</code></pre>`

And turndown is not accounting for those line breaks.

We could use innerText instead of textContent to account for them, but it's not
supported in JSDOM (https://github.com/jsdom/jsdom/issues/1245).

We could implement a crappy version of it which includes newlines generated by
`<br>`, but it seems better to teach the newline replacement about preformatted
text, and just use the already-processed content instead.