### PR TITLE
Look for class="language-*" in <pre> nodes as well.

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -109,7 +109,7 @@ rules.fencedCodeBlock = {
   },
 
   replacement: function (content, node, options) {
-    var className = node.firstChild.className || ''
+    var className = node.firstChild.className || node.className || ''
     var language = (className.match(/language-(\S+)/) || [null, ''])[1]
 
     return (


### PR DESCRIPTION
At least some CMSs may do that.