### PR TITLE
Apply the standard rule mechanism also to text nodes

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -2,6 +2,17 @@ import { repeat } from './utilities'
 
 var rules = {}
 
+rules.text = {
+  filter: '#text',
+
+  replacement: function (content, node, options) {
+    if (node.isCode) return node.nodeValue
+    return options.escapes.reduce(function (accumulator, escape) {
+      return accumulator.replace(escape[0], escape[1])
+    }, node.nodeValue).trim()
+  }
+}
+
 rules.paragraph = {
   filter: 'p',
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -6,7 +6,7 @@ import Node from './node'
 var reduce = Array.prototype.reduce
 var leadingNewLinesRegExp = /^\n*/
 var trailingNewLinesRegExp = /\n*$/
-var escapes = [
+var DEFAULT_ESCAPES = [
   [/\\/g, '\\\\'],
   [/\*/g, '\\*'],
   [/^-/g, '\\-'],
@@ -27,6 +27,7 @@ export default function TurndownService (options) {
 
   var defaults = {
     rules: COMMONMARK_RULES,
+    escapes: DEFAULT_ESCAPES,
     headingStyle: 'setext',
     hr: '* * *',
     bulletListMarker: '*',
@@ -130,20 +131,6 @@ TurndownService.prototype = {
   remove: function (filter) {
     this.rules.remove(filter)
     return this
-  },
-
-  /**
-   * Escapes Markdown syntax
-   * @public
-   * @param {String} string The string to escape
-   * @returns A string with Markdown syntax escaped
-   * @type String
-   */
-
-  escape: function (string) {
-    return escapes.reduce(function (accumulator, escape) {
-      return accumulator.replace(escape[0], escape[1])
-    }, string)
   }
 }
 
@@ -159,14 +146,7 @@ function process (parentNode) {
   var self = this
   return reduce.call(parentNode.childNodes, function (output, node) {
     node = new Node(node)
-
-    var replacement = ''
-    if (node.nodeType === 3) {
-      replacement = node.isCode ? node.nodeValue : self.escape(node.nodeValue)
-    } else if (node.nodeType === 1) {
-      replacement = replacementForNode.call(self, node)
-    }
-
+    var replacement = replacementForNode.call(self, node)
     return join(output, replacement)
   }, '')
 }


### PR DESCRIPTION
There might be strong reasons for creating rules also for text nodes. This simple patch makes it possible. We believe it even makes the current code more consistent, as we can rely on the node name "`#text`".

Backround:\
Our use case is related to text escaping. As the docs admit, it is quite simplistic and adds unnecessary backslashes. Unfortunately any simple GFM escaping also necessarily corrupts data. We aim at nearly-lossless conversions, so we have developed [GfmEscape](https://github.com/orchitech/gfm-escape) to address context-dependent escaping.

I admit that full escaping complexity might be overkill for Turndown.\
But Turndown is still a fantastic framework for user-developed conversions, so let's just provide the desired hook. :)

Thank you!