### PR TITLE
Do not skip empty table rows. Fixes domchristie#276.

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -10,7 +10,7 @@ export default function Node (node) {
 
 function isBlank (node) {
   return (
-    ['A', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'].indexOf(node.nodeName) === -1 &&
+    ['A', 'THEAD', 'TBODY', 'TR', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'].indexOf(node.nodeName) === -1 &&
     /^\s*$/i.test(node.textContent) &&
     !isVoid(node) &&
     !hasVoid(node)


### PR DESCRIPTION
Current implementation skips empty table rows, but it shouldn't as the specification says, that there can be empty row. This PR fixes #276, I didn't add TABLE intentionally as it was in #277.

Example 1:
```
<table>
  <thead>
    <tr>
      <th>Header</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td></td>
    </tr>
    <tr>
      <td>Cell</td>
    </tr>
  </tbody>
</table>
```
Should be
```
| Header |
| --- |
|  |
| Cell |
```

Example 2:
```
<table>
  <thead>
    <tr>
      <th></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Cell</td>
    </tr>
  </tbody>
</table>
```
Should be
```
|  |
| --- |
| Cell |