### PR TITLE
Correct Unicode whitespace collapsing and improve flanking white space

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -930,7 +930,7 @@ Baz</pre>
   <div class="input">
     <p>Foo<span>&nbsp;</span>Bar</p>
   </div>
-  <pre class="expected">Foo Bar</pre>
+  <pre class="expected">Foo&nbsp;Bar</pre>
 </div>
 
 <div class="case" data-name="triple tildes inside code" data-options='{"codeBlockStyle": "fenced", "fence": "~~~"}'>
@@ -987,6 +987,59 @@ Code
 Code
 
 ```</pre>
+</div>
+
+<div class="case" data-name="text separated by ASCII and nonASCII space in an element">
+  <div class="input">
+    <p>Foo<span>  &nbsp;  </span>Bar</p>
+  </div>
+  <pre class="expected">Foo &nbsp; Bar</pre>
+</div>
+
+<div class="case" data-name="list-like text with non-breaking spaces">
+  <div class="input">&nbsp;1. First<br>&nbsp;2. Second</div>
+  <pre class="expected">&nbsp;1. First  <!-- hard break -->
+&nbsp;2. Second</pre>
+</div>
+
+<div class="case" data-name="element with trailing nonASCII WS followed by nonWS">
+  <div class="input"><i>foo&nbsp;</i>bar</div>
+  <pre class="expected">_foo_&nbsp;bar</pre>
+</div>
+
+<div class="case" data-name="element with trailing nonASCII WS followed by nonASCII WS">
+  <div class="input"><i>foo&nbsp;</i>&nbsp;bar</div>
+  <pre class="expected">_foo_&nbsp;&nbsp;bar</pre>
+</div>
+
+<div class="case" data-name="element with trailing ASCII WS followed by nonASCII WS">
+  <div class="input"><i>foo </i>&nbsp;bar</div>
+  <pre class="expected">_foo_ &nbsp;bar</pre>
+</div>
+
+<div class="case" data-name="element with trailing nonASCII WS followed by ASCII WS">
+  <div class="input"><i>foo&nbsp;</i> bar</div>
+  <pre class="expected">_foo_&nbsp; bar</pre>
+</div>
+
+<div class="case" data-name="nonWS followed by element with leading nonASCII WS">
+  <div class="input">foo<i>&nbsp;bar</i></div>
+  <pre class="expected">foo&nbsp;_bar_</pre>
+</div>
+
+<div class="case" data-name="nonASCII WS followed by element with leading nonASCII WS">
+  <div class="input">foo&nbsp;<i>&nbsp;bar</i></div>
+  <pre class="expected">foo&nbsp;&nbsp;_bar_</pre>
+</div>
+
+<div class="case" data-name="nonASCII WS followed by element with leading ASCII WS">
+  <div class="input">foo&nbsp;<i> bar</i></div>
+  <pre class="expected">foo&nbsp; _bar_</pre>
+</div>
+
+<div class="case" data-name="ASCII WS followed by element with leading nonASCII WS">
+  <div class="input">foo <i>&nbsp;bar</i></div>
+  <pre class="expected">foo &nbsp;_bar_</pre>
 </div>
 
 <!-- /TEST CASES -->


### PR DESCRIPTION
Tuned whitespace handling, especially when ASCII and nonASCII whitespace is used together. Based on [this analysis](https://github.com/orchitech/turndown/wiki/Whitespace).

Quality assurance:
- One of the unit tests was adjusted to expect the right value. :)
- Added tests for all eight reasonable combinations.
- Added a test for false formatting, which was detected by integration tests in our project.

Performance:
- Blank element with spaces detection avoided.
- Edge whitespace matched in one regexp instead of two.
- Should be slightly faster than before.

From the commit message:
- Do not merge ASCII and non-ASCII whitespace.
- Make sure non-ASCII whitespace is moved out of inline elements to prevent generating broken Markdown.
- Fix #102.
- Fix #250.