### PR TITLE
Fix space-padding in code span rule

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -233,19 +233,15 @@ rules.code = {
   },
 
   replacement: function (content) {
-    if (!content.trim()) return ''
+    if (!content) return ''
+    content = content.replace(/\r?\n|\r/g, ' ')
 
+    var extraSpace = /^`|^ .*?[^ ].* $|`$/.test(content) ? ' ' : ''
     var delimiter = '`'
-    var leadingSpace = ''
-    var trailingSpace = ''
-    var matches = content.match(/`+/gm)
-    if (matches) {
-      if (/^`/.test(content)) leadingSpace = ' '
-      if (/`$/.test(content)) trailingSpace = ' '
-      while (matches.indexOf(delimiter) !== -1) delimiter = delimiter + '`'
-    }
+    var matches = content.match(/`+/gm) || []
+    while (matches.indexOf(delimiter) !== -1) delimiter = delimiter + '`'
 
-    return delimiter + leadingSpace + content + trailingSpace + delimiter
+    return delimiter + extraSpace + content + extraSpace + delimiter
   }
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -69,7 +69,7 @@ sit</pre>
 
 <div class="case" data-name="code starting with a backtick">
   <div class="input"><code>`starting with a backtick</code></div>
-  <pre class="expected">`` `starting with a backtick``</pre>
+  <pre class="expected">`` `starting with a backtick ``</pre>
 </div>
 
 <div class="case" data-name="code containing markdown syntax">


### PR DESCRIPTION
Code span rule now exactly conforms to the spec.

Quality assurance:
- Fixed expectation in a test expecting a wrong output.
- The fixed test matches fixed output.
- Code should now be more robust in terms of future development.

Performance:
- Saved one `trim()`
- Executing one more regexp (roughly).
- Less code. :)

From the commit message:
- Follow CommonMark spec more precisely
- Make the code span rule even more robust for future Turndown development.
- Fix #316.