### PR TITLE
Preformatted inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ var turndownService = new TurndownService({ option: 'value' })
 | `strongDelimiter`     | `**` or `__` | `**` |
 | `linkStyle`           | `inlined` or `referenced` | `inlined` |
 | `linkReferenceStyle`  | `full`, `collapsed`, or `shortcut` | `full` |
+| `preformattedCode`    | `false` or [`true`](https://github.com/lucthev/collapse-whitespace/issues/16) | `false` |
 
 ### Advanced Options
 

--- a/src/collapse-whitespace.js
+++ b/src/collapse-whitespace.js
@@ -41,7 +41,7 @@ function collapseWhitespace (options) {
   if (!element.firstChild || isPre(element)) return
 
   var prevText = null
-  var prevVoid = false
+  var keepLeadingWs = false
 
   var prev = null
   var node = next(prev, element, isPre)
@@ -51,7 +51,7 @@ function collapseWhitespace (options) {
       var text = node.data.replace(/[ \r\n\t]+/g, ' ')
 
       if ((!prevText || / $/.test(prevText.data)) &&
-          !prevVoid && text[0] === ' ') {
+          !keepLeadingWs && text[0] === ' ') {
         text = text.substr(1)
       }
 
@@ -71,11 +71,14 @@ function collapseWhitespace (options) {
         }
 
         prevText = null
-        prevVoid = false
-      } else if (isVoid(node)) {
-        // Avoid trimming space around non-block, non-BR void elements.
+        keepLeadingWs = false
+      } else if (isVoid(node) || isPre(node)) {
+        // Avoid trimming space around non-block, non-BR void elements and inline PRE.
         prevText = null
-        prevVoid = true
+        keepLeadingWs = true
+      } else if (prevText) {
+        // Drop protection if set previously.
+        keepLeadingWs = false
       }
     } else {
       node = remove(node)

--- a/src/root-node.js
+++ b/src/root-node.js
@@ -2,7 +2,7 @@ import collapseWhitespace from './collapse-whitespace'
 import HTMLParser from './html-parser'
 import { isBlock, isVoid } from './utilities'
 
-export default function RootNode (input) {
+export default function RootNode (input, options) {
   var root
   if (typeof input === 'string') {
     var doc = htmlParser().parseFromString(
@@ -19,7 +19,8 @@ export default function RootNode (input) {
   collapseWhitespace({
     element: root,
     isBlock: isBlock,
-    isVoid: isVoid
+    isVoid: isVoid,
+    isPre: options.preformattedCode ? isPreOrCode : null
   })
 
   return root
@@ -29,4 +30,8 @@ var _htmlParser
 function htmlParser () {
   _htmlParser = _htmlParser || new HTMLParser()
   return _htmlParser
+}
+
+function isPreOrCode (node) {
+  return node.nodeName === 'PRE' || node.nodeName === 'CODE'
 }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -37,6 +37,7 @@ export default function TurndownService (options) {
     linkStyle: 'inlined',
     linkReferenceStyle: 'full',
     br: '  ',
+    preformattedCode: false,
     blankReplacement: function (content, node) {
       return node.isBlock ? '\n\n' : ''
     },
@@ -69,7 +70,7 @@ TurndownService.prototype = {
 
     if (input === '') return ''
 
-    var output = process.call(this, new RootNode(input))
+    var output = process.call(this, new RootNode(input, this.options))
     return postProcess.call(this, output)
   },
 
@@ -158,7 +159,7 @@ TurndownService.prototype = {
 function process (parentNode) {
   var self = this
   return reduce.call(parentNode.childNodes, function (output, node) {
-    node = new Node(node)
+    node = new Node(node, self.options)
 
     var replacement = ''
     if (node.nodeType === 3) {

--- a/test/index.html
+++ b/test/index.html
@@ -1042,6 +1042,40 @@ Code
   <pre class="expected">foo &nbsp;_bar_</pre>
 </div>
 
+<!-- Behavior of `<code>` with CSS set as `white-space: pre-wrap;`, e.g. in GitLab -->
+<div class="case" data-name="preformatted code with leading whitespace" data-options='{"preformattedCode": true}'>
+  <div class="input">Four spaces <code>    make an indented code block in Markdown</code></div>
+  <pre class="expected">Four spaces `    make an indented code block in Markdown`</pre>
+</div>
+
+<div class="case" data-name="preformatted code with trailing whitespace" data-options='{"preformattedCode": true}'>
+  <div class="input"><code>A line break  </code> <b> note the spaces</b></div>
+  <pre class="expected">`A line break  ` **note the spaces**</pre>
+</div>
+
+<div class="case" data-name="preformatted code tightly surrounded" data-options='{"preformattedCode": true}'>
+  <div class="input"><b>tight</b><code>code</code><b>wrap</b></div>
+  <pre class="expected">**tight**`code`**wrap**</pre>
+</div>
+
+<div class="case" data-name="preformatted code loosely surrounded" data-options='{"preformattedCode": true}'>
+  <div class="input"><b>not so tight </b><code>code</code><b> wrap</b></div>
+  <pre class="expected">**not so tight** `code` **wrap**</pre>
+</div>
+
+<!-- newlines become spaces + extra space must be added  -->
+<div class="case" data-name="preformatted code with newlines" data-options='{"preformattedCode": true}'>
+  <div class="input">
+<code>
+
+ nasty
+code
+
+</code>
+  </div>
+  <pre class="expected">`    nasty code   `</pre>
+</div>
+
 <!-- /TEST CASES -->
 
 <script src="turndown-test.browser.js"></script>


### PR DESCRIPTION
Add support for interpreting `<code>` as a preformatted inline element and rendering Markdown accordingly. Fix #318.

This PR builds on previous PRs #315 and #317.

Quality assurance:
- Changes in `collapse-whitespace.js` also [submitted to the original `collapse-whitespace` project](https://github.com/lucthev/collapse-whitespace/pull/17). The code is the very same except for coding style nuances.
- All previous tests in the `collapse-whitespace` project pass. New tests added for the new behavior, checking it matches browser behavior.
- The rest of Turndown is unaffected without `preformattedCode` enabled.
- There is not much complexity added, actually preformatted code behaves almost like block elements.
- We believe it is a core thing related to basic HTML semantics, just like `<pre>` for block preformatted code. So merging this to Turndown's core is justifiable.

Performance:
- Couple of lines added.
- No new costly operations.