### PR TITLE
Ensure isBlank checks for significant elements within the given node

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -1,4 +1,4 @@
-import { isBlock, isVoid, hasVoid } from './utilities'
+import { isBlock, isVoid, hasVoid, isMeaningfulWhenBlank, hasMeaningfulWhenBlank } from './utilities'
 
 export default function Node (node) {
   node.isBlock = isBlock(node)
@@ -10,10 +10,11 @@ export default function Node (node) {
 
 function isBlank (node) {
   return (
-    ['A', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'].indexOf(node.nodeName) === -1 &&
-    /^\s*$/i.test(node.textContent) &&
     !isVoid(node) &&
-    !hasVoid(node)
+    !isMeaningfulWhenBlank(node) &&
+    /^\s*$/i.test(node.textContent) &&
+    !hasVoid(node) &&
+    !hasMeaningfulWhenBlank(node)
   )
 }
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -13,28 +13,53 @@ export function repeat (character, count) {
 }
 
 export var blockElements = [
-  'address', 'article', 'aside', 'audio', 'blockquote', 'body', 'canvas',
-  'center', 'dd', 'dir', 'div', 'dl', 'dt', 'fieldset', 'figcaption',
-  'figure', 'footer', 'form', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-  'header', 'hgroup', 'hr', 'html', 'isindex', 'li', 'main', 'menu', 'nav',
-  'noframes', 'noscript', 'ol', 'output', 'p', 'pre', 'section', 'table',
-  'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'ul'
+  'ADDRESS', 'ARTICLE', 'ASIDE', 'AUDIO', 'BLOCKQUOTE', 'BODY', 'CANVAS',
+  'CENTER', 'DD', 'DIR', 'DIV', 'DL', 'DT', 'FIELDSET', 'FIGCAPTION', 'FIGURE',
+  'FOOTER', 'FORM', 'FRAMESET', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER',
+  'HGROUP', 'HR', 'HTML', 'ISINDEX', 'LI', 'MAIN', 'MENU', 'NAV', 'NOFRAMES',
+  'NOSCRIPT', 'OL', 'OUTPUT', 'P', 'PRE', 'SECTION', 'TABLE', 'TBODY', 'TD',
+  'TFOOT', 'TH', 'THEAD', 'TR', 'UL'
 ]
 
 export function isBlock (node) {
-  return blockElements.indexOf(node.nodeName.toLowerCase()) !== -1
+  return is(node, blockElements)
 }
 
 export var voidElements = [
-  'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
-  'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+  'AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT',
+  'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'
 ]
 
 export function isVoid (node) {
-  return voidElements.indexOf(node.nodeName.toLowerCase()) !== -1
+  return is(node, voidElements)
 }
 
-var voidSelector = voidElements.join()
 export function hasVoid (node) {
-  return node.querySelector && node.querySelector(voidSelector)
+  return has(node, voidElements)
+}
+
+var meaningfulWhenBlankElements = [
+  'A', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TH', 'TD', 'IFRAME', 'SCRIPT',
+  'AUDIO', 'VIDEO'
+]
+
+export function isMeaningfulWhenBlank (node) {
+  return is(node, meaningfulWhenBlankElements)
+}
+
+export function hasMeaningfulWhenBlank (node) {
+  return has(node, meaningfulWhenBlankElements)
+}
+
+function is (node, tagNames) {
+  return tagNames.indexOf(node.nodeName) >= 0
+}
+
+function has (node, tagNames) {
+  return (
+    node.getElementsByTagName &&
+    tagNames.some(function (tagName) {
+      return node.getElementsByTagName(tagName).length
+    })
+  )
 }

--- a/test/turndown-test.js
+++ b/test/turndown-test.js
@@ -118,6 +118,16 @@ test('keep rules are overridden by the standard rules', function (t) {
   t.equal(turndownService.turndown('<p>Hello world</p>'), 'Hello world')
 })
 
+test('keeping elements that have a blank textContent but contain significant elements', function (t) {
+  t.plan(1)
+  var turndownService = new TurndownService()
+  turndownService.keep('figure')
+  t.equal(
+    turndownService.turndown('<figure><iframe src="http://example.com"></iframe></figure>'),
+    '<figure><iframe src="http://example.com"></iframe></figure>'
+  )
+})
+
 test('keepReplacement can be customised', function (t) {
   t.plan(1)
   var turndownService = new TurndownService({


### PR DESCRIPTION
[`isBlank`](https://github.com/domchristie/turndown/blob/46fc45b4042d8eb046c33b451182f13f105fd0ef/src/node.js#L11-L18) currently checks:
- if the element **is** meaningful  i.e. a `'A', 'TH', 'TD', 'IFRAME', 'SCRIPT', 'AUDIO', 'VIDEO'`,
- if the `textContent` is blank,
- if the element **is** a void, and
- if the element **contains** a void element

This works for most cases, although fails when the element **contains** a meaningful element and has a blank `textContent` e.g. 

```html
<figure><iframe src="…"></iframe></figure>
```

(Adapted from: https://github.com/domchristie/turndown/issues/293)

This pull request checks if the element contains a meaningful element. It also adds `'TABLE', 'THEAD', 'TBODY', 'TFOOT'` to the list of meaningful elements.

Fixes #293
Fixes #276 
Closes #277 
Closes #311 

