### PR TITLE
Fix browser modules export. Fixes domchristie/turndown#334.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "module": "lib/turndown.es.js",
   "jsnext:main": "lib/turndown.es.js",
   "browser": {
-    "domino": false
+    "domino": false,
+    "./lib/turndown.cjs.js": "./lib/turndown.browser.cjs.js",
+    "./lib/turndown.es.js": "./lib/turndown.browser.es.js",
+    "./lib/turndown.umd.js": "./lib/turndown.browser.umd.js"
   },
   "dependencies": {
     "domino": "^2.1.6"


### PR DESCRIPTION
This pull request fixes `browser` field exported by Turndown's `package.json`.

Motivation behind this PR:
I'm using Turndown as a dependency in another project and when I build `umd` package with Rollup.js, Turndown with JSDOM is included and there is no elegant way to replace it except modifying browser field. After that `rollup/plugin-node-resolve` can use the module exported by `browser` field when building my project.