### PR TITLE
Provide text escaping and replacement hooks for context-dependent escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ var turndownService = new TurndownService({ option: 'value' })
 | `blankReplacement`    | rule replacement function | See **Special Rules** below |
 | `keepReplacement`     | rule replacement function | See **Special Rules** below |
 | `defaultReplacement`  | rule replacement function | See **Special Rules** below |
+| `textReplacement`     | rule replacement function | See **Special Rules** below |
+| `escapes`             | array of replacement pairs | See [source code](https://github.com/domchristie/turndown/blob/master/src/turndown.js#L9) |
 
 ## Methods
 
@@ -196,6 +198,8 @@ rules.emphasis = {
 **Remove rules** determine which elements to remove altogether. By default, no elements are removed.
 
 **Default rule** handles nodes which are not recognised by any other rule. By default, it outputs the node's text content (separated  by blank lines if it is a block-level element). Its behaviour can be customised with the `defaultReplacement` option.
+
+**Text rule** handles text nodes. By default it preserves text under `<code>` elements and escapes all other text.
 
 ### Rule Precedence
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -7,6 +7,10 @@ export default function Rules (options) {
   this._keep = []
   this._remove = []
 
+  this.textRule = {
+    replacement: options.textReplacement
+  }
+
   this.blankRule = {
     replacement: options.blankReplacement
   }
@@ -43,6 +47,7 @@ Rules.prototype = {
   },
 
   forNode: function (node) {
+    if (node.nodeType === 3) return this.textRule
     if (node.isBlank) return this.blankRule
     var rule
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -6,7 +6,7 @@ import Node from './node'
 var reduce = Array.prototype.reduce
 var leadingNewLinesRegExp = /^\n*/
 var trailingNewLinesRegExp = /\n*$/
-var escapes = [
+var ESCAPES = [
   [/\\/g, '\\\\'],
   [/\*/g, '\\*'],
   [/^-/g, '\\-'],
@@ -25,8 +25,10 @@ var escapes = [
 export default function TurndownService (options) {
   if (!(this instanceof TurndownService)) return new TurndownService(options)
 
+  var self = this
   var defaults = {
     rules: COMMONMARK_RULES,
+    escapes: ESCAPES,
     headingStyle: 'setext',
     hr: '* * *',
     bulletListMarker: '*',
@@ -45,6 +47,9 @@ export default function TurndownService (options) {
     },
     defaultReplacement: function (content, node) {
       return node.isBlock ? '\n\n' + content + '\n\n' : content
+    },
+    textReplacement: function (content, node, options) {
+      return node.isCode ? content : self.escape(content, node, options)
     }
   }
   this.options = extend({}, defaults, options)
@@ -140,10 +145,10 @@ TurndownService.prototype = {
    * @type String
    */
 
-  escape: function (string) {
-    return escapes.reduce(function (accumulator, escape) {
+  escape: function (content, node, options) {
+    return options.escapes.reduce(function (accumulator, escape) {
       return accumulator.replace(escape[0], escape[1])
-    }, string)
+    }, content)
   }
 }
 
@@ -162,7 +167,8 @@ function process (parentNode) {
 
     var replacement = ''
     if (node.nodeType === 3) {
-      replacement = node.isCode ? node.nodeValue : self.escape(node.nodeValue)
+      var textRule = self.rules.forNode(node)
+      replacement = textRule.replacement(node.nodeValue, node, self.options)
     } else if (node.nodeType === 1) {
       replacement = replacementForNode.call(self, node)
     }


### PR DESCRIPTION
Provide text escaping and replacement hooks to allow implementing comprehensive, context-dependent escaping. See domchristie/turndown#324 as an example, where it is necessary to avoid data corruption.

This PR supersedes domchristie/turndown#304.