### PR TITLE
fix：use content to replace code, keep the code format

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -128,7 +128,7 @@ rules.fencedCodeBlock = {
 
     return (
       '\n\n' + fence + language + '\n' +
-      code.replace(/\n$/, '') +
+      content +
       '\n' + fence + '\n\n'
     )
   }


### PR DESCRIPTION
Here content should be used instead of code, but the test fails, which should be related to turndown-attendanty.