### PR TITLE
Alter list items (standalone and with header)

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -24,6 +24,12 @@ rules.heading = {
   replacement: function (content, node, options) {
     var hLevel = Number(node.nodeName.charAt(1))
 
+    var parent = node.parentNode
+    if (parent.nodeName === 'LI') {
+      if (!content.trim()) return ''
+      return options.strongDelimiter + content + options.strongDelimiter
+    }
+
     if (options.headingStyle === 'setext' && hLevel < 3) {
       var underline = repeat((hLevel === 1 ? '=' : '-'), content.length)
       return (
@@ -74,6 +80,7 @@ rules.listItem = {
       prefix = (start ? Number(start) + index : index + 1) + '.  '
     }
     return (
+      (node.previousSibling && node.previousSibling.nodeName !== 'LI' ? '\n' : '') +
       prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')
     )
   }

--- a/test/index.html
+++ b/test/index.html
@@ -651,6 +651,15 @@ Another div</pre>
 3.  Chapter Three with trailing whitespace</pre>
 </div>
 
+<div class="case" data-name="header inside list item">
+  <div class="input">
+    <ul>
+      <li><h1>Header inside list item</h1></li>
+    </ul>
+  </div>
+  <pre class="expected">*   **Header inside list item**</pre>
+</div>
+
 <div class="case" data-name="multilined and bizarre formatting">
   <div class="input">
     <ul>
@@ -669,6 +678,14 @@ Another div</pre>
 *   **Strong with trailing space inside li with leading/trailing whitespace**
 *   li without whitespace
 *   Leading space, text, lots of whitespace … text</pre>
+</div>
+
+<div class="case" data-name="standalone list item">
+  <div class="input">
+    <img src="logo.png" alt="Img with alt"> <li>Standalone list item</li>
+  </div>
+  <pre class="expected">![Img with alt](logo.png)
+*   Standalone list item</pre>
 </div>
 
 <div class="case" data-name="whitespace between inline elements">


### PR DESCRIPTION
- Header inside a list item becomes bold
- List item following a non-list-item node is placed on a new line
- Tests added for these cases

Fixes #357 