### PR TITLE
Added collapseMultipleWhitespaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ var turndownService = new TurndownService({ option: 'value' })
 | `linkStyle`           | `inlined` or `referenced` | `inlined` |
 | `linkReferenceStyle`  | `full`, `collapsed`, or `shortcut` | `full` |
 | `preformattedCode`    | `false` or [`true`](https://github.com/lucthev/collapse-whitespace/issues/16) | `false` |
+| `collapseMultipleWhitespaces` | `true` or `false` | `true` |
 
 ### Advanced Options
 

--- a/src/collapse-whitespace.js
+++ b/src/collapse-whitespace.js
@@ -37,6 +37,7 @@ function collapseWhitespace (options) {
   var isPre = options.isPre || function (node) {
     return node.nodeName === 'PRE'
   }
+  var collapseWhitespaces = options.collapseWhitespaces
 
   if (!element.firstChild || isPre(element)) return
 
@@ -48,7 +49,15 @@ function collapseWhitespace (options) {
 
   while (node !== element) {
     if (node.nodeType === 3 || node.nodeType === 4) { // Node.TEXT_NODE or Node.CDATA_SECTION_NODE
-      var text = node.data.replace(/[ \r\n\t]+/g, ' ')
+      var text
+
+      // Replace series of multiple whitespaces with a single one
+      if (collapseWhitespaces) {
+        text = node.data.replace(/[ \r\n\t]+/g, ' ')
+      } else {
+        // Replace only for leading and trailing
+        text = node.data.replace(/^[ \r\n\t]+|[ \r\n\t]+$/g, ' ')
+      }
 
       if ((!prevText || / $/.test(prevText.data)) &&
           !keepLeadingWs && text[0] === ' ') {

--- a/src/root-node.js
+++ b/src/root-node.js
@@ -20,7 +20,8 @@ export default function RootNode (input, options) {
     element: root,
     isBlock: isBlock,
     isVoid: isVoid,
-    isPre: options.preformattedCode ? isPreOrCode : null
+    isPre: options.preformattedCode ? isPreOrCode : null,
+    collapseWhitespaces: options.collapseMultipleWhitespaces
   })
 
   return root

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -38,6 +38,7 @@ export default function TurndownService (options) {
     linkReferenceStyle: 'full',
     br: '  ',
     preformattedCode: false,
+    collapseMultipleWhitespaces: true,
     blankReplacement: function (content, node) {
       return node.isBlock ? '\n\n' : ''
     },

--- a/test/index.html
+++ b/test/index.html
@@ -717,6 +717,16 @@ text after blank div</pre>
 Content in another div</pre>
 </div>
 
+<div class="case" data-name="preserve multiple whitespaces" data-options='{"collapseMultipleWhitespaces": false}'>
+  <div class="input"><a href="http://www.example.com">link with     spaces</a></div>
+  <pre class="expected">[link with     spaces](http://www.example.com)</pre>
+</div>
+
+<div class="case" data-name="trim string preserving multiple whitespaces" data-options='{"collapseMultipleWhitespaces": false}'>
+  <div class="input"><span>this <em>  is     an example       </em> with space</span></div>
+  <pre class="expected">this _is     an example_ with space</pre>
+</div>
+
 <div class="case" data-name="escaping backslashes">
   <div class="input">backslash \</div>
   <pre class="expected">backslash \\</pre>


### PR DESCRIPTION
Added an option `collapseMultipleWhitespaces` to replace series of multiple whitespaces with a single one, if `true`. Otherwise do that only for leading and trailing.

See #361 