### PR TITLE
Fix build when used as a git-linked dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build-umd": "rollup -c config/rollup.config.umd.js && rollup -c config/rollup.config.browser.umd.js",
     "build-iife": "rollup -c config/rollup.config.iife.js",
     "build-test": "browserify test/turndown-test.js --outfile test/turndown-test.browser.js",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "npm run build && npm run build-test && standard ./src/**/*.js && node test/turndown-test.js"
   }
 }


### PR DESCRIPTION
As stated at https://docs.npmjs.com/cli/v7/using-npm/scripts#prepare-and-prepublish:

> Deprecation Note: prepublish
> Since npm@1.1.71, the npm CLI has run the prepublish script for both npm publish and npm install, because it's a convenient way to prepare a package for use (some common use cases are described in the section below). It has also turned out to be, in practice, very confusing. As of npm@4.0.0, a new event has been introduced, prepare, that preserves this existing behavior. A new event, prepublishOnly has been added as a transitional strategy to allow users to avoid the confusing behavior of existing npm versions and only run on npm publish (for instance, running the tests one last time to ensure they're in good shape).