### PR TITLE
Add specific setup instructions for Vue users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,21 @@ var turndownService = new TurndownService()
 var markdown = turndownService.turndown('<h1>Hello world!</h1>')
 ```
 
+
+
 Turndown also accepts DOM nodes as input (either element nodes, document nodes,  or document fragment nodes):
 
 ```js
 var markdown = turndownService.turndown(document.getElementById('content'))
 ```
+
+If using Vue, you may see an error: `TypeError: TurndownService is not a constructor` when trying to import Turndown. To fix this, add `.default` to the import. In other words:
+```js
+// example.vue
+const TurndownService = require('turndown').default
+```
+
+
 
 ## Options
 


### PR DESCRIPTION

- Added `.default to allow Vue users to import turndown without failure. This is from https://stackoverflow.com/questions/55621010/using-turndown-in-vue-typeerror-turndownservice-is-not-a-constructor