### PR TITLE
Online demo: use the 'text/html' entry when available in the clipboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,18 @@ console.log(
 
     input.addEventListener('input', update)
 
+    input.addEventListener('paste', function (e) {
+      var clipboardData = e.clipboardData
+      if (!clipboardData || !clipboardData.getData) {
+        return
+      }
+      var html = clipboardData.getData('text/html')
+      if (html && document.queryCommandSupported('insertText')) {
+        e.preventDefault()
+        document.execCommand('insertText', false, html)
+      }
+    })
+
     optionsForm.addEventListener('change', function () {
       turndownService = new window.TurndownService(options())
       update()


### PR DESCRIPTION
I'm using Turndown's online demo a lot these days to turn HTML into Markdown, thank you so much for the library and associated service!

One thing I find myself needing to do a lot is to go to [Clipboard inspector](https://evercoder.github.io/clipboard-inspector/), paste the content _there_, then copy the `text/html` clipboard entry as plain text, before pasting it in the [Turndown demo](https://mixmark-io.github.io/turndown/).

It would be great if the tool picked up on the `text/html` clipboard entry directly. In this PR I've made it do just that, let me know what you think! 