### PR TITLE
fix #410

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -62,16 +62,24 @@ rules.listItem = {
   filter: 'li',
 
   replacement: function (content, node, options) {
+    const spaces = 2
+    let prefix = ''
     content = content
       .replace(/^\n+/, '') // remove leading newlines
       .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
-      .replace(/\n/gm, '\n    ') // indent
-    var prefix = options.bulletListMarker + '   '
-    var parent = node.parentNode
+    const parent = node.parentNode
     if (parent.nodeName === 'OL') {
-      var start = parent.getAttribute('start')
-      var index = Array.prototype.indexOf.call(parent.children, node)
-      prefix = (start ? Number(start) + index : index + 1) + '.  '
+      const start = parseInt(parent.getAttribute('start')) || 0
+      const digits = Math.log(parent.children.length + start) * Math.LOG10E + 1 | 0
+      const index = Array.prototype.indexOf.call(parent.children, node)
+      const itemNumber = (start ? Number(start) + index : index + 1)
+      const suffix = '.'
+      const padding = (digits > spaces ? digits + 1 : spaces + 1) + suffix.length // increase padding if beyond 99
+      prefix = (itemNumber + suffix).padEnd(padding)
+      content = content.replace(/\n/gm, '\n  '.padEnd(1 + padding))
+    } else {
+      prefix = options.bulletListMarker + ' '.padEnd(1 + spaces)
+      content = content.replace(/\n/gm, '\n  '.padEnd(3 + spaces)) // indent
     }
     return (
       prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')

--- a/test/index.html
+++ b/test/index.html
@@ -371,9 +371,31 @@ def a_fenced_code block; end
       <li>Ordered list item 44</li>
     </ol>
   </div>
-  <pre class="expected">42.  Ordered list item 42
-43.  Ordered list item 43
-44.  Ordered list item 44</pre>
+  <pre class="expected">42. Ordered list item 42
+43. Ordered list item 43
+44. Ordered list item 44</pre>
+</div>
+
+<div class="case" data-name="ol with increasing start">
+  <div class="input">
+    <ol start="9">
+      <li>Ordered list item 9</li>
+      <li>Ordered list item 10</li>
+    </ol>
+  </div>
+  <pre class="expected">9.  Ordered list item 9
+10. Ordered list item 10</pre>
+</div>
+
+<div class="case" data-name="ol with high start">
+  <div class="input">
+    <ol start="99">
+      <li>Ordered list item 99</li>
+      <li>Ordered list item 100</li>
+    </ol>
+  </div>
+  <pre class="expected">99.  Ordered list item 99
+100. Ordered list item 100</pre>
 </div>
 
 <div class="case" data-name="list spacing">
@@ -461,6 +483,28 @@ Another paragraph.
 2.  A paragraph in a second list item.</pre>
 </div>
 
+<div class="case" data-name="ol with start and paragraphs">
+  <div class="input">
+    <ol start="9">
+      <li>
+        <p>This is a paragraph in a list item.</p>
+        <p>This is a paragraph in the same list item as above.</p>
+      </li>
+      <li>
+        <p>A paragraph in a second list item.</p>
+        <p>This is a paragraph in the same list item as above.</p>
+      </li>
+    </ol>
+  </div>
+  <pre class="expected">9.  This is a paragraph in a list item.
+    
+    This is a paragraph in the same list item as above.
+    
+10. A paragraph in a second list item.
+    
+    This is a paragraph in the same list item as above.</pre>
+</div>
+
 <div class="case" data-name="nested uls">
   <div class="input">
     <ul>
@@ -498,7 +542,7 @@ Another paragraph.
       <li>This is a list item at root level</li>
       <li>This is another item at root level</li>
       <li>
-        <ol>
+        <ol start="9">
           <li>This is a nested list item</li>
           <li>This is another nested list item</li>
           <li>
@@ -515,9 +559,9 @@ Another paragraph.
   </div>
   <pre class="expected">*   This is a list item at root level
 *   This is another item at root level
-*   1.  This is a nested list item
-    2.  This is another nested list item
-    3.  *   This is a deeply nested list item
+*   9.  This is a nested list item
+    10. This is another nested list item
+    11. *   This is a deeply nested list item
         *   This is another deeply nested list item
         *   This is a third deeply nested list item
 *   This is a third item at root level</pre>


### PR DESCRIPTION
Sandbox of this patch in action: https://stackblitz.com/edit/vitejs-vite-btuys7?file=main.js,index.html

Fix 410 by reducing the padding if the number of digits in the list grows. Also fixes issues with numbers over 99. Making the mid LI spacing adjustable is possible, but not part of this commit. 

In deeply nested lists, indentation can still be broken for ordered lists over 99 nested inside other lists. A fix is difficult to implement without very very slow tree walking code.

This PR results in the following 
![Screenshot from 2022-05-11 14-42-35](https://user-images.githubusercontent.com/876076/167932625-1b4943af-a8ea-4f73-a4e1-4f964736a620.png)

without the PR the paragraph would be misaligned like the following:

```
9.  This is a paragraph in a list item.
    
    This is a paragraph in the same list item as above.
    
10.  A paragraph in a second list item.
    
    This is a paragraph in the same list item as above.
```

Which github would correctly render as the following unexpected code_block:

9.  This is a paragraph in a list item.
    
    This is a paragraph in the same list item as above.
    
10.  A paragraph in a second list item.
    
    This is a paragraph in the same list item as above.
