### PR TITLE
Fix 'window is not defined' in React Server Components

### DIFF
--- a/src/html-parser.js
+++ b/src/html-parser.js
@@ -27,7 +27,7 @@ function canParseHTMLNatively () {
 function createHTMLParser () {
   var Parser = function () {}
 
-  if (process.browser) {
+  if (process.browser && typeof window !== 'undefined') {
     if (shouldUseActiveX()) {
       Parser.prototype.parseFromString = function (string) {
         var doc = new window.ActiveXObject('htmlfile')


### PR DESCRIPTION
- Fixes the `window is not defined` error when used in RSC

<img width="1812" alt="Screenshot 2023-04-25 at 10 12 43 PM" src="https://user-images.githubusercontent.com/92991945/234449006-feae455f-f32e-443b-99c2-f16792af4aeb.png">
