### PR TITLE
Add TEXTAREA as part of the void elements

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -38,7 +38,7 @@ export function isBlock (node) {
 
 export var voidElements = [
   'AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT',
-  'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR'
+  'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR', 'TEXTAREA'
 ]
 
 export function isVoid (node) {


### PR DESCRIPTION
TEXTAREA should be considered a void element just like INPUT is.
TextArea elements are getting discarded incorrectly by the blank rule as they are not considered void elements.