### PR TITLE
Fixing a missing defensive check for an absent window global variable that was breaking service worker environments

### DIFF
--- a/src/html-parser.js
+++ b/src/html-parser.js
@@ -60,7 +60,7 @@ function shouldUseActiveX () {
   try {
     document.implementation.createHTMLDocument('').open()
   } catch (e) {
-    if (window.ActiveXObject) useActiveX = true
+    if (root.ActiveXObject) useActiveX = true
   }
   return useActiveX
 }


### PR DESCRIPTION
Reusing the `root` variable defined in the file above - and used in a similar way on line 12 - we can enable service worker environments to use this library.
Otherwise these environments will encounter a `window is not defined` error.

This will close #397.