### PR TITLE
Support for nested <ul>/<ol> tags without <li> (not technically valid)

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -73,10 +73,9 @@ rules.listItem = {
     var prefix = options.bulletListMarker + '   '
     var parent = node.parentNode
     // Don't print double prefixes when ul/ol is nested inside an empty li
-    if (node.children.length === 1 && node.children[0].nodeName.match(/^(UL|OL)$/i) && node.textContent === node.children[0].textContent ) {
+    if (node.children.length === 1 && node.children[0].nodeName.match(/^(UL|OL)$/i) && node.textContent === node.children[0].textContent) {
       prefix = '    '
-    }
-    else if (parent.nodeName === 'OL') {
+    } else if (parent.nodeName === 'OL') {
       var start = parent.getAttribute('start')
       var index = Array.prototype.indexOf.call(parent.children, node)
       prefix = (start ? Number(start) + index : index + 1) + '.  '

--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -52,7 +52,10 @@ rules.list = {
     var parent = node.parentNode
     // It may not be technically valid, but owing to common usage this library should support nested ul/ol outside of li
     if (node.parentNode.nodeName.match(/^(UL|OL)$/i)) {
-      content = '    ' + content.replace(/\n/gm, '\n    ')
+      content = '    ' + content
+        .replace(/^\n+/, '') // remove leading newlines
+        .replace(/\n+$/, '\n') // replace trailing newlines with just a single one
+        .replace(/\n/gm, '\n    ') // indent
     }
     if (parent.nodeName === 'LI' && parent.lastElementChild === node) {
       return '\n' + content
@@ -72,12 +75,10 @@ rules.listItem = {
       .replace(/\n/gm, '\n    ') // indent
     var prefix = options.bulletListMarker + '   '
     var parent = node.parentNode
-    // Don't print double prefixes when ul/ol is nested inside an empty li
-    if (node.children.length === 1 && node.children[0].nodeName.match(/^(UL|OL)$/i) && node.textContent === node.children[0].textContent) {
-      prefix = '    '
-    } else if (parent.nodeName === 'OL') {
+
+    if (parent.nodeName === 'OL') {
       var start = parent.getAttribute('start')
-      var index = Array.prototype.indexOf.call(parent.children, node)
+      var index = Array.prototype.indexOf.call(Array.prototype.filter.call(parent.children, el => el.nodeName === 'LI'), node)
       prefix = (start ? Number(start) + index : index + 1) + '.  '
     }
     return (

--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -50,7 +50,6 @@ rules.list = {
 
   replacement: function (content, node) {
     var parent = node.parentNode
-    // It may not be technically valid, but owing to common usage this library should support nested ul/ol outside of li
     if (node.parentNode.nodeName.match(/^(UL|OL)$/i)) {
       content = '    ' + content
         .replace(/^\n+/, '') // remove leading newlines
@@ -75,7 +74,6 @@ rules.listItem = {
       .replace(/\n/gm, '\n    ') // indent
     var prefix = options.bulletListMarker + '   '
     var parent = node.parentNode
-
     if (parent.nodeName === 'OL') {
       var start = parent.getAttribute('start')
       var index = Array.prototype.indexOf.call(Array.prototype.filter.call(parent.children, el => el.nodeName === 'LI'), node)

--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -50,6 +50,10 @@ rules.list = {
 
   replacement: function (content, node) {
     var parent = node.parentNode
+    // It may not be technically valid, but owing to common usage this library should support nested ul/ol outside of li
+    if (node.parentNode.nodeName.match(/^(UL|OL)$/i)) {
+      content = '    ' + content.replace(/\n/gm, '\n    ')
+    }
     if (parent.nodeName === 'LI' && parent.lastElementChild === node) {
       return '\n' + content
     } else {
@@ -68,7 +72,11 @@ rules.listItem = {
       .replace(/\n/gm, '\n    ') // indent
     var prefix = options.bulletListMarker + '   '
     var parent = node.parentNode
-    if (parent.nodeName === 'OL') {
+    // Don't print double prefixes when ul/ol is nested inside an empty li
+    if (node.children.length === 1 && node.children[0].nodeName.match(/^(UL|OL)$/i) && node.textContent === node.children[0].textContent ) {
+      prefix = '    '
+    }
+    else if (parent.nodeName === 'OL') {
       var start = parent.getAttribute('start')
       var index = Array.prototype.indexOf.call(parent.children, node)
       prefix = (start ? Number(start) + index : index + 1) + '.  '

--- a/test/index.html
+++ b/test/index.html
@@ -523,6 +523,98 @@ Another paragraph.
 *   This is a third item at root level</pre>
 </div>
 
+
+<div class="case" data-name="nested ols and uls as intended">
+  <div class="input">
+    <ul>
+      <li>This is a list item at root level</li>
+      <li>This is another item at root level
+        <ol>
+          <li>This is a nested list item</li>
+          <li>This is another nested list item
+            <ul>
+              <li>This is a deeply nested list item</li>
+              <li>This is another deeply nested list item</li>
+              <li>This is a third deeply nested list item</li>
+            </ul>
+          </li>
+        </ol>
+      </li>
+      <li>This is a third item at root level</li>
+    </ul>
+  </div>
+  <pre class="expected">*   This is a list item at root level
+*   This is another item at root level
+    1.  This is a nested list item
+    2.  This is another nested list item
+        *   This is a deeply nested list item
+        *   This is another deeply nested list item
+        *   This is a third deeply nested list item
+*   This is a third item at root level</pre>
+</div>
+
+<div class="case" data-name="nested ols and uls outside of li">
+  <div class="input">
+    <ul>
+      <li>This is a list item at root level</li>
+      <li>This is another item at root level</li>
+      <ol>
+        <li>This is a nested list item</li>
+        <li>This is another nested list item</li>
+        <ul>
+          <li>This is a deeply nested list item</li>
+          <li>This is another deeply nested list item</li>
+          <li>This is a third deeply nested list item</li>
+        </ul>
+      </ol>
+      <li>This is a third item at root level</li>
+    </ul>
+  </div>
+  <pre class="expected">*   This is a list item at root level
+*   This is another item at root level
+
+    1.  This is a nested list item
+    2.  This is another nested list item
+    
+        *   This is a deeply nested list item
+        *   This is another deeply nested list item
+        *   This is a third deeply nested list item
+    
+
+*   This is a third item at root level</pre>
+</div>
+
+<div class="case" data-name="nested ols outside li">
+  <div class="input">
+    <ol>
+      <li>item 1</li>
+      <li>item 2</li>
+      <ol>
+        <li>item 2.1</li>
+        <li>item 2.2</li>
+        <ol>
+          <li>item 2.2.1</li>
+          <li>item 2.2.2</li>
+          <li>item 2.2.3</li>
+        </ol>
+      </ol>
+      <li>item 3</li>
+    </ol>
+  </div>
+  <pre class="expected">1.  item 1
+2.  item 2
+
+    1.  item 2.1
+    2.  item 2.2
+    
+        1.  item 2.2.1
+        2.  item 2.2.2
+        3.  item 2.2.3
+    
+
+3.  item 3</pre>
+</div>
+
 <div class="case" data-name="ul with blockquote">
   <div class="input">
     <ul>


### PR DESCRIPTION
I'm opening this pull request for your re-consideration of issue #232. My reasoning is this:

1. Although this syntax is invalid HTML, it has de-facto support in all browsers.
2. Some people are making this mistake in writing their HTML.
3. Converting that HTML to Markdown changes the semantic meaning that is clear in the original.
4. It wasn't that hard to fix.

Please see [my comment](https://github.com/mixmark-io/turndown/issues/232#issuecomment-1659413071) on #232.

Note that this PR differs slightly from the code that I pasted there; I think it's unnecessary to "fix" the case with an empty `<li>` element (`<li><ul>...</ul></li>`) because the meaning is preserved in the resulting markdown.