### PR TITLE
Fix bug where li with first child that's a block rendered incorrectly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turndown",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turndown",
-      "version": "7.1.2",
+      "version": "7.1.3",
       "license": "MIT",
       "dependencies": {
         "domino": "^2.1.6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "turndown",
   "description": "A library that converts HTML to Markdown",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "author": "Dom Christie",
   "main": "lib/turndown.cjs.js",
   "module": "lib/turndown.es.js",

--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -68,13 +68,28 @@ rules.listItem = {
       .replace(/\n/gm, '\n    ') // indent
     var prefix = options.bulletListMarker + '   '
     var parent = node.parentNode
+
+    // Check if the first child is a block-level element
+    var blockElements = [
+      'address', 'article', 'aside', 'blockquote', 'canvas', 'dd', 'div',
+      'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'li', 'main',
+      'nav', 'noscript', 'ol', 'p', 'pre', 'section', 'table', 'tfoot',
+      'ul', 'video'
+    ].map(function (t) {
+      return t.toUpperCase()
+    })
+
+    var firstChildIsBlock = node.firstChild && blockElements.includes(node.firstChild.nodeName)
+
     if (parent.nodeName === 'OL') {
       var start = parent.getAttribute('start')
       var index = Array.prototype.indexOf.call(parent.children, node)
       prefix = (start ? Number(start) + index : index + 1) + '.  '
     }
+
     return (
-      prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')
+      prefix + (firstChildIsBlock ? '\n\n    ' : '') + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '')
     )
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -404,6 +404,38 @@ Another paragraph.
 *   Unordered list item 3</pre>
 </div>
 
+<div class="case" data-name="ol with li that has block-level first child (heading)">
+  <div class="input">
+    <ol>
+      <li>Inline</li>
+      <li>
+        <h1>Block</h1>
+      </li>
+    </ol>
+  </div>
+  <pre class="expected">1.  Inline
+2.  
+
+    Block
+    =====</pre>
+</div>
+
+<div class="case" data-name="ul with li that has block-level first child (heading)">
+  <div class="input">
+    <ul>
+      <li>Inline</li>
+      <li>
+        <h1>Block</h1>
+      </li>
+    </ul>
+  </div>
+  <pre class="expected">*   Inline
+*   
+
+    Block
+    =====</pre>
+</div>
+
 <div class="case" data-name="ul">
   <div class="input">
     <ul>
@@ -437,7 +469,9 @@ Another paragraph.
       <li>List item without paragraph</li>
     </ul>
   </div>
-  <pre class="expected">*   List item with paragraph
+  <pre class="expected">*   
+
+    List item with paragraph
     
 *   List item without paragraph</pre>
 </div>
@@ -454,11 +488,15 @@ Another paragraph.
       </li>
     </ol>
   </div>
-  <pre class="expected">1.  This is a paragraph in a list item.
+  <pre class="expected">1.  
+
+    This is a paragraph in a list item.
     
     This is a paragraph in the same list item as above.
     
-2.  A paragraph in a second list item.</pre>
+2.  
+
+    A paragraph in a second list item.</pre>
 </div>
 
 <div class="case" data-name="nested uls">
@@ -484,9 +522,13 @@ Another paragraph.
   </div>
   <pre class="expected">*   This is a list item at root level
 *   This is another item at root level
-*   *   This is a nested list item
+*   
+
+    *   This is a nested list item
     *   This is another nested list item
-    *   *   This is a deeply nested list item
+    *   
+    
+        *   This is a deeply nested list item
         *   This is another deeply nested list item
         *   This is a third deeply nested list item
 *   This is a third item at root level</pre>
@@ -515,9 +557,13 @@ Another paragraph.
   </div>
   <pre class="expected">*   This is a list item at root level
 *   This is another item at root level
-*   1.  This is a nested list item
+*   
+
+    1.  This is a nested list item
     2.  This is another nested list item
-    3.  *   This is a deeply nested list item
+    3.  
+    
+        *   This is a deeply nested list item
         *   This is another deeply nested list item
         *   This is a third deeply nested list item
 *   This is a third item at root level</pre>
@@ -534,7 +580,9 @@ Another paragraph.
       </li>
     </ul>
   </div>
-  <pre class="expected">*   A list item with a blockquote:
+  <pre class="expected">*   
+
+    A list item with a blockquote:
     
     > This is a blockquote inside a list item.</pre>
 </div>


### PR DESCRIPTION
Fixes the first issue mentioned in #357. I describe the bug in more detail here: https://github.com/mixmark-io/turndown/issues/357#issuecomment-1694699312

The modified tests technically already cover the bug fix but I added a couple of tests to make the desired behavior more explicit.