### PR TITLE
Allow TurndownService to accept custom HTML parsers

### DIFF
--- a/src/root-node.js
+++ b/src/root-node.js
@@ -1,16 +1,14 @@
 import collapseWhitespace from './collapse-whitespace'
-import HTMLParser from './html-parser'
 import { isBlock, isVoid } from './utilities'
 
-export default function RootNode (input, options) {
+export default function RootNode (input, parseHTMLString, options) {
   var root
   if (typeof input === 'string') {
-    var doc = htmlParser().parseFromString(
+    var doc = parseHTMLString(
       // DOM parsers arrange elements in the <head> and <body>.
       // Wrapping in a custom element ensures elements are reliably arranged in
       // a single element.
       '<x-turndown id="turndown-root">' + input + '</x-turndown>',
-      'text/html'
     )
     root = doc.getElementById('turndown-root')
   } else {
@@ -24,12 +22,6 @@ export default function RootNode (input, options) {
   })
 
   return root
-}
-
-var _htmlParser
-function htmlParser () {
-  _htmlParser = _htmlParser || new HTMLParser()
-  return _htmlParser
 }
 
 function isPreOrCode (node) {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -1,6 +1,7 @@
 import COMMONMARK_RULES from './commonmark-rules'
 import Rules from './rules'
 import { extend, trimLeadingNewlines, trimTrailingNewlines } from './utilities'
+import HTMLParser from './html-parser'
 import RootNode from './root-node'
 import Node from './node'
 var reduce = Array.prototype.reduce
@@ -36,6 +37,7 @@ export default function TurndownService (options) {
     linkReferenceStyle: 'full',
     br: '  ',
     preformattedCode: false,
+    htmlParser: new HTMLParser(),
     blankReplacement: function (content, node) {
       return node.isBlock ? '\n\n' : ''
     },
@@ -68,7 +70,10 @@ TurndownService.prototype = {
 
     if (input === '') return ''
 
-    var output = process.call(this, new RootNode(input, this.options))
+    var parseHTMLString = htmlString => 
+      this.options.htmlParser.parseFromString(htmlString, 'text/html')
+
+    var output = process.call(this, new RootNode(input, parseHTMLString, this.options))
     return postProcess.call(this, output)
   },
 


### PR DESCRIPTION
This solves a problem for me where I need to run turndown in a service worker. That environment doesn't support either the DOM API-based or `domino`-based solutions that turndown's `HTMLParser` implementation only supports. I talked a bit more about this in https://github.com/mixmark-io/turndown/pull/443#issuecomment-2003173563

With this change I can pass in a `HTMLParser`-compatible object to the `TurndownService` constructor, implemented using a package like `linkedom` which affords a DOM-like API and works fine in a service worker context.

It should not change anything for existing users in either standard (DOM accessible) browser or node contexts as the existing `HTMLParser` implementation should still be used by default.