### PR TITLE
Escape parenthesis in link URLs. Fix #459.

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -153,8 +153,9 @@ rules.inlineLink = {
 
   replacement: function (content, node) {
     var href = node.getAttribute('href')
+    if (href) href = href.replace(/([()])/g, '\\$1')
     var title = cleanAttribute(node.getAttribute('title'))
-    if (title) title = ' "' + title + '"'
+    if (title) title = ' "' + title.replace(/"/g, '\\"') + '"'
     return '[' + content + '](' + href + title + ')'
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -217,6 +217,16 @@ title")</pre>
 link")</pre>
 </div>
 
+<div class="case" data-name="a with quotes in title">
+  <div class="input"><a href="http://example.com" title="&quot;hello&quot;">An anchor</a></div>
+  <pre class="expected">[An anchor](http://example.com "\"hello\"")</pre>
+</div>
+
+<div class="case" data-name="a with parenthesis in query">
+  <div class="input"><a href="http://example.com?(query)">An anchor</a></div>
+  <pre class="expected">[An anchor](http://example.com?\(query\))</pre>
+</div>
+
 <div class="case" data-name="a without a src">
   <div class="input"><a id="about-anchor">Anchor without a title</a></div>
   <pre class="expected">Anchor without a title</pre>


### PR DESCRIPTION
This adds escaping parenthesis according to Common Mark spec - https://spec.commonmark.org/0.31.2/#link-destination.

Alternative solution would be to detect presence of parenthesis and enclosing the link in pointy brackets `[text](<link>)`.