### PR TITLE
Switch to custom Domino fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Turndown input is
 
 When a string input is passed, the DOM parser is picked as follows.
 * For web browser usage, the corresponding native web parser is used, which is typically `DOMImplementation`.
-* For standalone usage, [domino](https://github.com/fgnass/domino) parser is used.
+* For standalone usage, custom [domino](https://github.com/mixmark-io/domino) parser is used.
 
 Please note that a malicious string input can cause undesired effects within the DOM parser
 even before Turndown code starts processing the document itself.
@@ -27,8 +27,8 @@ better suits your security needs.
 
 In particular, Turndown version 6 and below used [jsdom](https://github.com/jsdom/jsdom) as the
 standalone DOM parser. As `jsdom` is a fully featured DOM parser with script execution support,
-it imposes an inherent security risk. We recommend upgrading to version 7, which uses
-[domino](https://github.com/fgnass/domino) that doesn't even support executing scripts nor
+it imposes an inherent security risk. We recommend upgrading to version 7, which uses custom
+[domino](https://github.com/mixmark-io/domino) that doesn't even support executing scripts nor
 downloading external resources.
 
 ## Reporting a Vulnerability

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -6,7 +6,7 @@ export default function (config) {
   return {
     input: 'src/turndown.js',
     output: config.output,
-    external: ['domino'],
+    external: ['@mixmark-io/domino'],
     plugins: [
       commonjs(),
       replace({ 'process.browser': JSON.stringify(!!config.browser), preventAssignment: true }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.1.3",
       "license": "MIT",
       "dependencies": {
-        "domino": "^2.1.6"
+        "@mixmark-io/domino": "^2.2.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^19.0.0",
@@ -187,6 +187,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "19.0.0",
@@ -1434,11 +1439,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/domino": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
-      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "node_modules/dotignore": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "module": "lib/turndown.es.js",
   "jsnext:main": "lib/turndown.es.js",
   "browser": {
-    "domino": false,
+    "@mixmark-io/domino": false,
     "./lib/turndown.cjs.js": "./lib/turndown.browser.cjs.js",
     "./lib/turndown.es.js": "./lib/turndown.browser.es.js",
     "./lib/turndown.umd.js": "./lib/turndown.browser.umd.js"
   },
   "dependencies": {
-    "domino": "^2.1.6"
+    "@mixmark-io/domino": "^2.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.0",

--- a/src/html-parser.js
+++ b/src/html-parser.js
@@ -47,7 +47,7 @@ function createHTMLParser () {
       }
     }
   } else {
-    var domino = require('domino')
+    var domino = require('@mixmark-io/domino')
     Parser.prototype.parseFromString = function (string) {
       return domino.createDocument(string)
     }


### PR DESCRIPTION
This PR switches from vanilla Domino to our custom fork https://www.npmjs.com/package/@mixmark-io/domino (see mixmark-io/domino#1). This should fix issues when bundling Turndown together with the default parser (#378).

I have updated all instances of `'domino'` to `'@mixmark-io/domino'`. Not sure if there are any other places that needs attention.