### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on: 
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node_version: [18, 20, 21]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-  - "10"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Turndown
 
-[![Build Status](https://travis-ci.org/domchristie/turndown.svg?branch=master)](https://travis-ci.org/domchristie/turndown)
-
 Convert HTML into Markdown with JavaScript.
 
 ## Project Updates


### PR DESCRIPTION
I don't think Travis CI was working after moving the repository under Mixmark.io organization. GitHub Actions is perfectly fine and we can do without the external dependency.

Seems like the original `.travis.yml` was using Node.js 10. However Node.js 10 had NPM which was not able to use scoped dependencies and that will be used by #461 (`@mixmark-io/domino`). GH Action config now tests only with supported LTS releases (18, 20) and the most recent release (21).

Main branch protection can be enabled after this is merged.