### PR TITLE
Properly escape inline link and image attributes. Fix #473.

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, trimNewlines } from './utilities'
+import { escapeMarkdown, repeat, trimNewlines } from './utilities'
 
 var rules = {}
 
@@ -150,11 +150,10 @@ rules.inlineLink = {
   },
 
   replacement: function (content, node) {
-    var href = node.getAttribute('href')
-    if (href) href = href.replace(/([()])/g, '\\$1')
-    var title = cleanAttribute(node.getAttribute('title'))
-    if (title) title = ' "' + title.replace(/"/g, '\\"') + '"'
-    return '[' + content + '](' + href + title + ')'
+    var href = escapeLinkDestination(node.getAttribute('href'))
+    var title = escapeLinkTitle(cleanAttribute(node.getAttribute('title')))
+    var titlePart = title ? ' "' + title + '"' : ''
+    return '[' + content + '](' + href + titlePart + ')'
   }
 }
 
@@ -170,7 +169,7 @@ rules.referenceLink = {
   replacement: function (content, node, options) {
     var href = node.getAttribute('href')
     var title = cleanAttribute(node.getAttribute('title'))
-    if (title) title = ' "' + title + '"'
+    if (title) title = ' "' + escapeLinkTitle(title) + '"'
     var replacement
     var reference
 
@@ -248,16 +247,24 @@ rules.image = {
   filter: 'img',
 
   replacement: function (content, node) {
-    var alt = cleanAttribute(node.getAttribute('alt'))
-    var src = node.getAttribute('src') || ''
+    var alt = escapeMarkdown(cleanAttribute(node.getAttribute('alt')))
+    var src = escapeLinkDestination(node.getAttribute('src') || '')
     var title = cleanAttribute(node.getAttribute('title'))
-    var titlePart = title ? ' "' + title + '"' : ''
+    var titlePart = title ? ' "' + escapeLinkTitle(title) + '"' : ''
     return src ? '![' + alt + ']' + '(' + src + titlePart + ')' : ''
   }
 }
 
 function cleanAttribute (attribute) {
   return attribute ? attribute.replace(/(\n+\s*)+/g, '\n') : ''
+}
+
+function escapeLinkDestination (destination) {
+  return destination.replace(/([()])/g, '\\$1')
+}
+
+function escapeLinkTitle (title) {
+  return title.replace(/"/g, '\\"')
 }
 
 export default rules

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -1,24 +1,9 @@
 import COMMONMARK_RULES from './commonmark-rules'
 import Rules from './rules'
-import { extend, trimLeadingNewlines, trimTrailingNewlines } from './utilities'
+import { escapeMarkdown, extend, trimLeadingNewlines, trimTrailingNewlines } from './utilities'
 import RootNode from './root-node'
 import Node from './node'
 var reduce = Array.prototype.reduce
-var escapes = [
-  [/\\/g, '\\\\'],
-  [/\*/g, '\\*'],
-  [/^-/g, '\\-'],
-  [/^\+ /g, '\\+ '],
-  [/^(=+)/g, '\\$1'],
-  [/^(#{1,6}) /g, '\\$1 '],
-  [/`/g, '\\`'],
-  [/^~~~/g, '\\~~~'],
-  [/\[/g, '\\['],
-  [/\]/g, '\\]'],
-  [/^>/g, '\\>'],
-  [/_/g, '\\_'],
-  [/^(\d+)\. /g, '$1\\. ']
-]
 
 export default function TurndownService (options) {
   if (!(this instanceof TurndownService)) return new TurndownService(options)
@@ -140,9 +125,7 @@ TurndownService.prototype = {
    */
 
   escape: function (string) {
-    return escapes.reduce(function (accumulator, escape) {
-      return accumulator.replace(escape[0], escape[1])
-    }, string)
+    return escapeMarkdown(string)
   }
 }
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -78,3 +78,25 @@ function has (node, tagNames) {
     })
   )
 }
+
+var markdownEscapes = [
+  [/\\/g, '\\\\'],
+  [/\*/g, '\\*'],
+  [/^-/g, '\\-'],
+  [/^\+ /g, '\\+ '],
+  [/^(=+)/g, '\\$1'],
+  [/^(#{1,6}) /g, '\\$1 '],
+  [/`/g, '\\`'],
+  [/^~~~/g, '\\~~~'],
+  [/\[/g, '\\['],
+  [/\]/g, '\\]'],
+  [/^>/g, '\\>'],
+  [/_/g, '\\_'],
+  [/^(\d+)\. /g, '$1\\. ']
+]
+
+export function escapeMarkdown (string) {
+  return markdownEscapes.reduce(function (accumulator, escape) {
+    return accumulator.replace(escape[0], escape[1])
+  }, string)
+}

--- a/test/index.html
+++ b/test/index.html
@@ -171,9 +171,19 @@ after the break</pre>
   <pre class="expected">![img with alt](logo.png)</pre>
 </div>
 
+<div class="case" data-name="img with escaped content in alt">
+  <div class="input"><img src="logo.png" alt="_img_ *with* [alt]"></div>
+  <pre class="expected">![\_img\_ \*with\* \[alt\]](logo.png)</pre>
+</div>
+
 <div class="case" data-name="img with no src">
   <div class="input"><img></div>
   <pre class="expected"></pre>
+</div>
+
+<div class="case" data-name="img with parenthesis in src">
+  <div class="input"><img src="logo.png?(query)"></div>
+  <pre class="expected">![](logo.png?\(query\))</pre>
 </div>
 
 <div class="case" data-name="img with a new line in alt">
@@ -197,6 +207,11 @@ alt](logo.png)</pre>
     title"></div>
   <pre class="expected">![](logo.png "the
 title")</pre>
+</div>
+
+<div class="case" data-name="img with quotes in title">
+  <div class="input"><img src="logo.png" title="&quot;hello&quot;"></div>
+  <pre class="expected">![](logo.png "\"hello\"")</pre>
 </div>
 
 <div class="case" data-name="a">
@@ -237,6 +252,11 @@ link")</pre>
   <pre class="expected">[Some `code`](http://example.com/code)</pre>
 </div>
 
+<div class="case" data-name="a with a brackets in text">
+  <div class="input"><a href="http://example.com/code">Some [text]</a></div>
+  <pre class="expected">[Some \[text\]](http://example.com/code)</pre>
+</div>
+
 <div class="case" data-name="a reference" data-options='{"linkStyle": "referenced"}'>
   <div class="input"><a href="http://example.com">Reference link</a></div>
   <pre class="expected">[Reference link][1]
@@ -256,6 +276,13 @@ link")</pre>
   <pre class="expected">[Reference link with shortcut style]
 
 [Reference link with shortcut style]: http://example.com</pre>
+</div>
+
+<div class="case" data-name="a reference with title" data-options='{"linkStyle": "referenced"}'>
+  <div class="input"><a href="http://example.com" title="Hello &quot; World">Reference link</a></div>
+  <pre class="expected">[Reference link][1]
+
+[1]: http://example.com "Hello \" World"</pre>
 </div>
 
 <div class="case" data-name="pre/code block">


### PR DESCRIPTION
I have added proper escaping to images that is in line with the previous PR #460.

CommonMark specification defines rules for images +/- in the following way - "do the same as for links". So I have extracted the shared logic for escaping titles and links to dedicated functions.

Image `alt` attribute is used as link text. This text should have all markdown syntax escaped. For that purpose I have added new function `escapeMarkdown`, which is functionally the same as `turndown.escape`. This was necessary to prevent circular dependency and unnecessary refactoring.

### A bit about new escapeMarkdown function

The new implementation is pretty different in a sense that it uses single regex with a mixture of non-capturing / capturing groups and a single look-ahead assertion. This means that some ancient runtime environment might have issues with it... Not sure if that is of any concertn, but at least compatibility tables on MDN and caniuse.com for the used features have the same versions as the RegExp itself:

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group#browser_compatibility
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion#browser_compatibility

We might want to create a single shared implementation of that function. But I am not sure how to approach this . The function is probably pretty good candidate for its own file (_escape-markdown.js_) or maybe it can be placed in _utils.js_.

Also we might want to do some performance testing to pick which function will perform better. The new regular expression is more complex, but the OG function executes 13 separate regular expressions on any given content. So my gut tells me that on any average sized content the new regex will perform better... would be nice to actually verify that.