### PR TITLE
fix: fix deep nested code in pre

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -84,15 +84,14 @@ rules.indentedCodeBlock = {
     return (
       options.codeBlockStyle === 'indented' &&
       node.nodeName === 'PRE' &&
-      node.firstChild &&
-      node.firstChild.nodeName === 'CODE'
+      node.querySelector('code')
     )
   },
 
   replacement: function (content, node, options) {
     return (
       '\n\n    ' +
-      node.firstChild.textContent.replace(/\n/g, '\n    ') +
+      node.querySelector('code').textContent.replace(/\n/g, '\n    ') +
       '\n\n'
     )
   }
@@ -103,15 +102,15 @@ rules.fencedCodeBlock = {
     return (
       options.codeBlockStyle === 'fenced' &&
       node.nodeName === 'PRE' &&
-      node.firstChild &&
-      node.firstChild.nodeName === 'CODE'
+      node.querySelector('code')
     )
   },
 
   replacement: function (content, node, options) {
-    var className = node.firstChild.getAttribute('class') || ''
+    var codeElement = node.querySelector('code')
+    var className = codeElement.getAttribute('class') || ''
     var language = (className.match(/language-(\S+)/) || [null, ''])[1]
-    var code = node.firstChild.textContent
+    var code = codeElement.textContent
 
     var fenceChar = options.fence.charAt(0)
     var fenceSize = 3

--- a/test/turndown-test.js
+++ b/test/turndown-test.js
@@ -178,3 +178,21 @@ test('remove elements are overridden by keep', function (t) {
     'Hello <del>world</del><ins>World</ins>'
   )
 })
+
+test('deep nested code in pre is converted to code block (indented)', function (t) {
+  t.plan(1)
+  var turndownService = new TurndownService()
+  t.equal(turndownService.turndown(
+    '<pre><div><code>Hi</code></div></pre>'),
+    '    Hi'
+  )
+})
+
+test('deep nested code in pre is converted to code block (fenced)', function (t) {
+  t.plan(1)
+  var turndownService = new TurndownService({ codeBlockStyle: 'fenced' })
+  t.equal(turndownService.turndown(
+    '<pre><div><code>Hi</code></div></pre>'),
+    '```\nHi\n```'
+  )
+})


### PR DESCRIPTION
If a `<code>` element is not a direct child of a `<pre>`, turndown will not convert it to a code block but to inline code. This is the case for ChatGPT code blocks. This PR fixes it by not using `firstChild` but `querySelector('code')`.