### PR TITLE
Fix undefined Parser in nodejs environment

### DIFF
--- a/src/html-parser.js
+++ b/src/html-parser.js
@@ -16,7 +16,7 @@ function canParseHTMLNatively () {
   // Firefox/Opera/IE throw errors on unsupported types
   try {
     // WebKit returns null on unsupported types
-    if (new Parser().parseFromString('', 'text/html')) {
+    if (Parser && new Parser().parseFromString('', 'text/html')) {
       canParse = true
     }
   } catch (e) {}


### PR DESCRIPTION
I could not use the lib in nodejs environment.
I received an exception:
`Exception has occurred: TypeError: Parser is not a constructor`. 
Not sure why try/catch can't handle this, but simple checking if var `Parser` is present solves the issue.