### PR TITLE
Fixed Italics Whitespace Issue

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -212,7 +212,7 @@ rules.emphasis = {
 
   replacement: function (content, node, options) {
     if (!content.trim()) return ''
-    return options.emDelimiter + content + options.emDelimiter
+    return options.emDelimiter + content.trim() + options.emDelimiter
   }
 }
 


### PR DESCRIPTION
## Description
   Fixes issue with whitespace handling in emphasis formatting, where trailing spaces were being included in the Markdown output (e.g., `*example *` instead of `*example*`). The function would incorrectly translate <em>word </em> to _word _ instead of to _word_.  I fixed the issue by trimming whitespace before adding the delimiters back in.

## Testing
 All 296 existing tests pass, and the original body of text where I noticed this issue is handled correctly as well, as demonstrated below. The following is an excerpt from Matt Levine's great newsletter Money Stuff. Notice that the main branch messes up 2 out of three emphasized words or phrases, while my branch gets them all.

Main Branch:
What made it a great trade was *interest*. If you sought appraisal, you rejected the deal price and took your chances in court instead. The acquirer would cash out everyone else's shares at $10, but you wouldn't get the $10; you'd go to court. You'd argue your case, and then, months or years later, there would be a result. Either you would win (the judge would agree with you that the company was worth $15) and you'd get your $15, or you'd lose (the judge would agree with the acquirer that the company was worth $10) andyou'd get $10, or something in between (you'd get $12 or whatever). But in any case, the Delaware law provides that you get *interest *on the money, from the time the deal closed (and everyone else got their $10) to the time you get your money ($10 or $12 or $15 or whatever you get). And the interest is set at the Federal Reserve's discount rate plus 5%, compounded quarterly. [1]

And so you could do this trade:

1.  Buy stock in the company after the deal is announced but before it closes, paying $9.95 or whatever per share (because it's about to be cashed out at $10).
2.  Demand appraisal.
3.  Wait two years and get back *at least *$10 plus interest at 5% over the discount rate, which is pretty good, particularly in a low-interest-rate environment and with fairly low credit risk.
4.  And maybe you'll get $15!

My Branch:
What made it a great trade was _interest_. If you sought appraisal, you rejected the deal price and took your chances in court instead. The acquirer would cash out everyone else’s shares at $10, but you wouldn’t get the $10; you’d go to court. You’d argue your case, and then, months or years later, there would be a result. Either you would win (the judge would agree with you that the company was worth $15) and you’d get your $15, or you’d lose (the judge would agree with the acquirer that the company was worth $10) and you’d get $10, or something in between (you’d get $12 or whatever). But in any case, the Delaware law provides that you get _interest_ on the money, from the time the deal closed (and everyone else got their $10) to the time you get your money ($10 or $12 or $15 or whatever you get). And the interest is set at the Federal Reserve’s discount rate plus 5%, compounded quarterly.[\[1\]](https://mail.google.com/mail/u/0/#m_4149060104737802183_footnote-1)

And so you could do this trade:

1.  Buy stock in the company after the deal is announced but before it closes, paying $9.95 or whatever per share (because it’s about to be cashed out at $10).
2.  Demand appraisal.
3.  Wait two years and get back _at least_ $10 plus interest at 5% over the discount rate, which is pretty good, particularly in a low-interest-rate environment and with fairly low credit risk.
4.  And maybe you’ll get $15!