### PR TITLE
Prevent multiline image alt text

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -251,6 +251,8 @@ rules.image = {
 
   replacement: function (content, node) {
     var alt = cleanAttribute(node.getAttribute('alt'))
+    // Replace one or more consecutive line breaks with ' - '
+    alt = alt.replace(/(\r?\n\s*)+/g, ' - ')
     var src = node.getAttribute('src') || ''
     var title = cleanAttribute(node.getAttribute('title'))
     var titlePart = title ? ' "' + title + '"' : ''


### PR DESCRIPTION
Many (most?) markdown parsers don't support multiline img alt-texts (Hugo for example). So this is a fix for that.

Replacing from html img multiline alt-texts to single line. Replacing newlines with " - ". Multiple newlines will be replaced by only one " - ".