### PR TITLE
Use largest `srcset` URL in `<img>` elements (#305)

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, trimNewlines } from './utilities'
+import { repeat, trimNewlines, findLargestSource } from './utilities'
 
 var rules = {}
 
@@ -249,7 +249,7 @@ rules.image = {
 
   replacement: function (content, node) {
     var alt = cleanAttribute(node.getAttribute('alt'))
-    var src = node.getAttribute('src') || ''
+    var src = findLargestSource(node.getAttribute('srcset')) || node.getAttribute('src') || ''
     var title = cleanAttribute(node.getAttribute('title'))
     var titlePart = title ? ' "' + title + '"' : ''
     return src ? '![' + alt + ']' + '(' + src + titlePart + ')' : ''

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -78,3 +78,22 @@ function has (node, tagNames) {
     })
   )
 }
+
+export function findLargestSource (srcset) {
+  if (!srcset) return undefined
+  var maxURL
+  var maxResolution = 0
+  var sources = srcset.trim().split(/\s*,\s*/)
+
+  for (var i = 0; i < sources.length; i++) {
+    var parts = sources[i].split(/\s+/)
+    var descriptor = parts[1] || '1x'
+    var resolution = parseFloat(descriptor.slice(0, descriptor.length - 1))
+    if (resolution > maxResolution) {
+      maxResolution = resolution
+      maxURL = parts[0]
+    }
+  }
+
+  return maxURL
+}

--- a/test/index.html
+++ b/test/index.html
@@ -199,6 +199,29 @@ alt](logo.png)</pre>
 title")</pre>
 </div>
 
+<div class="case" data-name="img with srcset">
+  <div class="input"><img srcset="
+      http://example.com/logo.png,
+      http://example.com/logo-2x.png     2x,
+      http://example.com/logo-4x.png   4.0x,
+      http://example.com/logo-4.5x.png 4.5x
+    "></div>
+  <pre class="expected">![](http://example.com/logo-4.5x.png)</pre>
+</div>
+
+<div class="case" data-name="img with srcset and src">
+  <div class="input"><img src="http://example.com/logo-32x32.png" srcset="
+      http://example.com/logo-128x128.png 128w,
+      http://example.com/logo-64x64.png    64w
+    "></div>
+  <pre class="expected">![](http://example.com/logo-128x128.png)</pre>
+</div>
+
+<div class="case" data-name="img with empty srcset">
+  <div class="input"><img src="http://example.com/logo.png" srcset=""></div>
+  <pre class="expected">![](http://example.com/logo.png)</pre>
+</div>
+
 <div class="case" data-name="a">
   <div class="input"><a href="http://example.com">An anchor</a></div>
   <pre class="expected">[An anchor](http://example.com)</pre>


### PR DESCRIPTION
Close #305. If an image has a `srcset` attribute, use the largest source from there in place of the `src` attribute. This is useful as some websites (notably Tumblr) do not set a `src` for most images. Without these changes, Turndown would not render these images.

I'm interested in this issue because it causes problems saving certain webpages with [obsidianmd/obsidian-clipper](https://github.com/obsidianmd/obsidian-clipper), which has Turndown as a dependency. I figured it would be better to fix the issue here than submit a PR there. Also, this is my first open-source contribution, so please let me know if I'm doing anything wrong :)