### PR TITLE
Escape markdown within img alt attribute

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -1,4 +1,4 @@
-import { repeat, trimNewlines } from './utilities'
+import { repeat, trimNewlines, escape } from './utilities'
 
 var rules = {}
 
@@ -248,7 +248,7 @@ rules.image = {
   filter: 'img',
 
   replacement: function (content, node) {
-    var alt = cleanAttribute(node.getAttribute('alt'))
+    var alt = escape(cleanAttribute(node.getAttribute('alt')))
     var src = node.getAttribute('src') || ''
     var title = cleanAttribute(node.getAttribute('title'))
     var titlePart = title ? ' "' + title + '"' : ''

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -1,24 +1,9 @@
 import COMMONMARK_RULES from './commonmark-rules'
 import Rules from './rules'
-import { extend, trimLeadingNewlines, trimTrailingNewlines } from './utilities'
+import { extend, trimLeadingNewlines, trimTrailingNewlines, escape } from './utilities'
 import RootNode from './root-node'
 import Node from './node'
 var reduce = Array.prototype.reduce
-var escapes = [
-  [/\\/g, '\\\\'],
-  [/\*/g, '\\*'],
-  [/^-/g, '\\-'],
-  [/^\+ /g, '\\+ '],
-  [/^(=+)/g, '\\$1'],
-  [/^(#{1,6}) /g, '\\$1 '],
-  [/`/g, '\\`'],
-  [/^~~~/g, '\\~~~'],
-  [/\[/g, '\\['],
-  [/\]/g, '\\]'],
-  [/^>/g, '\\>'],
-  [/_/g, '\\_'],
-  [/^(\d+)\. /g, '$1\\. ']
-]
 
 export default function TurndownService (options) {
   if (!(this instanceof TurndownService)) return new TurndownService(options)
@@ -139,11 +124,7 @@ TurndownService.prototype = {
    * @type String
    */
 
-  escape: function (string) {
-    return escapes.reduce(function (accumulator, escape) {
-      return accumulator.replace(escape[0], escape[1])
-    }, string)
-  }
+  'escape': escape
 }
 
 /**

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -78,3 +78,33 @@ function has (node, tagNames) {
     })
   )
 }
+
+const escapes = [
+  [/\\/g, '\\\\'],
+  [/\*/g, '\\*'],
+  [/^-/g, '\\-'],
+  [/^\+ /g, '\\+ '],
+  [/^(=+)/g, '\\$1'],
+  [/^(#{1,6}) /g, '\\$1 '],
+  [/`/g, '\\`'],
+  [/^~~~/g, '\\~~~'],
+  [/\[/g, '\\['],
+  [/\]/g, '\\]'],
+  [/^>/g, '\\>'],
+  [/_/g, '\\_'],
+  [/^(\d+)\. /g, '$1\\. ']
+]
+
+/**
+ * Escapes Markdown syntax
+ * @public
+ * @param {String} string The string to escape
+ * @returns A string with Markdown syntax escaped
+ * @type String
+ */
+
+export function escape (string) {
+  return escapes.reduce(function (accumulator, escape) {
+    return accumulator.replace(escape[0], escape[1])
+  }, string)
+}

--- a/test/index.html
+++ b/test/index.html
@@ -199,6 +199,11 @@ alt](logo.png)</pre>
 title")</pre>
 </div>
 
+<div class="case" data-name="GH #513 img with markdown chars in alt">
+  <div class="input"> <img src="figure.jpg" alt="[Image]"></div>
+  <pre class="expected">![\[Image\]](figure.jpg)</pre>
+</div>
+
 <div class="case" data-name="a">
   <div class="input"><a href="http://example.com">An anchor</a></div>
   <pre class="expected">[An anchor](http://example.com)</pre>


### PR DESCRIPTION
This patch moves the escape() function to utilities.js and imports it into turndown service and the rule that escapes the attribute

This addresses GH issue #513 