### PR TITLE
Fix escaping link destination with spaces

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -167,7 +167,7 @@ rules.referenceLink = {
   },
 
   replacement: function (content, node, options) {
-    var href = node.getAttribute('href')
+    var href = escapeLinkDestination(node.getAttribute('href'))
     var title = cleanAttribute(node.getAttribute('title'))
     if (title) title = ' "' + escapeLinkTitle(title) + '"'
     var replacement
@@ -260,7 +260,8 @@ function cleanAttribute (attribute) {
 }
 
 function escapeLinkDestination (destination) {
-  return destination.replace(/([()])/g, '\\$1')
+  var escaped = destination.replace(/([<>()])/g, '\\$1')
+  return escaped.indexOf(' ') >= 0 ? '<' + escaped + '>' : escaped
 }
 
 function escapeLinkTitle (title) {

--- a/test/index.html
+++ b/test/index.html
@@ -214,9 +214,19 @@ title")</pre>
   <pre class="expected">![](logo.png "\"hello\"")</pre>
 </div>
 
+<div class="case" data-name="img with space in URL">
+  <div class="input"><img src="logo 1.png" alt="An image"></div>
+  <pre class="expected">![An image](&lt;logo 1.png&gt;)</pre>
+</div>
+
 <div class="case" data-name="a">
   <div class="input"><a href="http://example.com">An anchor</a></div>
   <pre class="expected">[An anchor](http://example.com)</pre>
+</div>
+
+<div class="case" data-name="a with space in URL">
+  <div class="input"><a href="http://example.com/foo bar">An anchor</a></div>
+  <pre class="expected">[An anchor](&lt;http://example.com/foo bar&gt;)</pre>
 </div>
 
 <div class="case" data-name="a with title">
@@ -262,6 +272,13 @@ link")</pre>
   <pre class="expected">[Reference link][1]
 
 [1]: http://example.com</pre>
+</div>
+
+<div class="case" data-name="a reference with space in URL" data-options='{"linkStyle": "referenced"}'>
+  <div class="input"><a href="http://example.com/foo bar">Reference link</a></div>
+  <pre class="expected">[Reference link][1]
+
+[1]: &lt;http://example.com/foo bar&gt;</pre>
 </div>
 
 <div class="case" data-name="a reference with collapsed style" data-options='{"linkStyle": "referenced", "linkReferenceStyle": "collapsed"}'>


### PR DESCRIPTION
This is a simple fix to enclose link destination in `<>` if the link contains spaces (fixes #467).

Reference: https://spec.commonmark.org/0.31.2/#link-destination