### PR TITLE
fix: use `*` for intraword emphasis so `_` is not emitted between words

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -209,7 +209,26 @@ rules.emphasis = {
 
   replacement: function (content, node, options) {
     if (!content.trim()) return ''
-    return options.emDelimiter + content + options.emDelimiter
+    var delimiter = options.emDelimiter
+    // A `_` delimiter cannot open or close emphasis between two word characters
+    // (CommonMark intraword rule), so `x<em>e</em>t` would emit `x_e_t`, which
+    // renders as literal text. Fall back to `*` only when the delimiter sits
+    // directly between word characters. Any whitespace on the element's edge is
+    // moved outside the delimiters, which already makes `_` safe there.
+    if (delimiter === '_') {
+      var word = /[\p{L}\p{N}]/u
+      var text = node.textContent
+      var previous = node.previousSibling
+      var next = node.nextSibling
+      var before = previous && previous.nodeType === 3 ? previous.nodeValue.slice(-1) : ''
+      var after = next && next.nodeType === 3 ? next.nodeValue.charAt(0) : ''
+      var openIntraword = !/\s/.test(text.charAt(0)) &&
+        word.test(before) && word.test(content.charAt(0))
+      var closeIntraword = !/\s/.test(text.charAt(text.length - 1)) &&
+        word.test(after) && word.test(content.charAt(content.length - 1))
+      if (openIntraword || closeIntraword) delimiter = '*'
+    }
+    return delimiter + content + delimiter
   }
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,16 @@ sit</pre>
   <pre class="expected">_em element_</pre>
 </div>
 
+<div class="case" data-name="intraword em uses asterisks">
+  <div class="input">x<em>e</em>t</div>
+  <pre class="expected">x*e*t</pre>
+</div>
+
+<div class="case" data-name="em adjacent to whitespace keeps underscores">
+  <div class="input">said <em>hi</em> now</div>
+  <pre class="expected">said _hi_ now</pre>
+</div>
+
 <div class="case" data-name="i">
   <div class="input"><i>i element</i></div>
   <pre class="expected">_i element_</pre>


### PR DESCRIPTION
Closes #269.

A `_` delimiter cannot open or close emphasis between two word characters (CommonMark intraword rule, GFM §6.2). The emphasis rule wrapped `<em>`/`<i>` in the default `_` unconditionally, so any emphasis touching word characters was emitted as literal text that no longer renders as emphasis:

```js
turndown("<p>x<em>e</em>t</p>")   // "x_e_t"  -> renders as literal "x_e_t"
turndown("<p>1<em>2</em>3</p>")   // "1_2_3"
```

(`<strong>` is unaffected because its `**` default has no intraword restriction.)

The fix falls back to `*` only when the `_` would sit directly between word characters. turndown already moves whitespace on the element edge outside the delimiters, so `_` is preserved wherever it is valid:

```js
turndown("<p>said <em>hi</em> now</p>")   // "said _hi_ now"  (unchanged)
turndown("<p>foo<em> bar </em>baz</p>")   // whitespace stays outside, `_` kept
```

Word characters are matched with `\p{L}\p{N}` so non-ASCII letters are handled (`café<em>ñ</em>z` → `café*ñ*z`). Added regression fixtures for the intraword and word-boundary cases; full suite passes (318).