### PR TITLE
Fix code block detection when whitespace precedes the inner <code>

### DIFF
--- a/src/commonmark-rules.js
+++ b/src/commonmark-rules.js
@@ -82,15 +82,15 @@ rules.indentedCodeBlock = {
     return (
       options.codeBlockStyle === 'indented' &&
       node.nodeName === 'PRE' &&
-      node.firstChild &&
-      node.firstChild.nodeName === 'CODE'
+      node.firstElementChild &&
+      node.firstElementChild.nodeName === 'CODE'
     )
   },
 
   replacement: function (content, node, options) {
     return (
       '\n\n    ' +
-      node.firstChild.textContent.replace(/\n/g, '\n    ') +
+      node.firstElementChild.textContent.replace(/\n/g, '\n    ') +
       '\n\n'
     )
   }
@@ -101,15 +101,15 @@ rules.fencedCodeBlock = {
     return (
       options.codeBlockStyle === 'fenced' &&
       node.nodeName === 'PRE' &&
-      node.firstChild &&
-      node.firstChild.nodeName === 'CODE'
+      node.firstElementChild &&
+      node.firstElementChild.nodeName === 'CODE'
     )
   },
 
   replacement: function (content, node, options) {
-    const className = node.firstChild.getAttribute('class') || ''
+    const className = node.firstElementChild.getAttribute('class') || ''
     const language = (className.match(/language-(\S+)/) || [null, ''])[1]
-    const code = node.firstChild.textContent
+    const code = node.firstElementChild.textContent
 
     const fenceChar = options.fence.charAt(0)
     let fenceSize = 3

--- a/test/index.html
+++ b/test/index.html
@@ -367,6 +367,22 @@ def a_fenced_code block; end
 ```</pre>
 </div>
 
+<div class="case" data-name="fenced pre/code block with whitespace before code" data-options='{"codeBlockStyle": "fenced"}'>
+  <div class="input">
+    <pre> <code>def a_fenced_code block; end</code></pre>
+  </div>
+  <pre class="expected">```
+def a_fenced_code block; end
+```</pre>
+</div>
+
+<div class="case" data-name="indented pre/code block with whitespace before code" data-options='{"codeBlockStyle": "indented"}'>
+  <div class="input">
+    <pre> <code>def an_indented_code block; end</code></pre>
+  </div>
+  <pre class="expected">    def an_indented_code block; end</pre>
+</div>
+
 <div class="case" data-name="pre/code block fenced with ~" data-options='{"codeBlockStyle": "fenced", "fence": "~~~"}'>
   <div class="input">
     <pre><code>def a_fenced_code block; end</code></pre>


### PR DESCRIPTION
The indentedCodeBlock and fencedCodeBlock rules checked node.firstChild to find the inner <code> element of a <pre>. When any whitespace separates the tags (e.g. <pre> <code>...</code></pre>), firstChild is a text node, so the check failed and the block was emitted as inline code instead of a code block.

Use node.firstElementChild, which skips text nodes and returns the first child element, so the <code> is found regardless of surrounding whitespace.

Adds regression tests for both fenced and indented styles with whitespace before the <code> element.