### PR TITLE
Escape ordered list items that use ) as the marker delimiter

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -92,7 +92,7 @@ const markdownEscapes = [
   [/\]/g, '\\]'],
   [/^>/g, '\\>'],
   [/_/g, '\\_'],
-  [/^(\d+)\. /g, '$1\\. ']
+  [/^(\d+)([.)]) /g, '$1\\$2 ']
 ]
 
 export function escapeMarkdown (string) {

--- a/test/index.html
+++ b/test/index.html
@@ -860,6 +860,16 @@ Content in another div</pre>
   <pre class="expected">1984.George Orwell wrote 1984.</pre>
 </div>
 
+<div class="case" data-name="escaping ol markdown with ) delimiter">
+  <div class="input">1984) by George Orwell</div>
+  <pre class="expected">1984\) by George Orwell</pre>
+</div>
+
+<div class="case" data-name="not escaping ) outside of an ol">
+  <div class="input">1984)George Orwell wrote 1984)</div>
+  <pre class="expected">1984)George Orwell wrote 1984)</pre>
+</div>
+
 <div class="case" data-name="escaping ul markdown *">
   <div class="input">* An unordered list item</div>
   <pre class="expected">\* An unordered list item</pre>


### PR DESCRIPTION
`escapeMarkdown` escapes text that would otherwise be parsed as Markdown. For ordered lists it only handled the `.` delimiter:

```js
[/^(\d+)\. /g, '$1\. ']
```

The CommonMark spec defines an ordered list marker as a sequence of digits followed by *either* a `.` or a `)` character (https://spec.commonmark.org/0.31.2/, "List items"). Because only `.` was handled, text content like `1) by George Orwell` was emitted unescaped and a CommonMark parser turns it back into an ordered list.

This adds `)` to the same delimiter group and escapes whichever delimiter matched:

```js
[/^(\d+)([.)]) /g, '$1\$2 ']
```

The existing `1984. by George Orwell` -> `1984\. by George Orwell` behaviour is unchanged. I added two cases next to the current ordered-list ones, mirroring the existing `.` pair:

- `1984) by George Orwell` -> `1984\) by George Orwell`
- `1984)George Orwell wrote 1984)` stays unescaped (no trailing space, and not at the start of a line), so this does not over-escape stray parentheses.

All 318 tests pass.
