### PR TITLE
Add 'trustedTypes?.emptyHTML' for `canParseHTMLNatively` check

### DIFF
--- a/src/html-parser.js
+++ b/src/html-parser.js
@@ -16,7 +16,7 @@ function canParseHTMLNatively () {
   // Firefox/Opera/IE throw errors on unsupported types
   try {
     // WebKit returns null on unsupported types
-    if (new Parser().parseFromString('', 'text/html')) {
+    if (new Parser().parseFromString(trustedTypes?.emptyHTML ?? '', 'text/html')) {
       canParse = true
     }
   } catch (e) {}


### PR DESCRIPTION
The PR fixes this issue https://github.com/mixmark-io/turndown/issues/533 by using `emptyHTML` trusted type.