### PR TITLE
Add Dockerfile and entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:alpine
+
+WORKDIR /app
+
+COPY . .
+RUN npm ci
+
+WORKDIR /src
+
+ENTRYPOINT ["node", "/app/bin/turndown-cli.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY . .
 RUN npm ci
+RUN npm install --no-save turndown-plugin-gfm@^1.0.2
 
 WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ Browser:
 
 For usage with RequireJS, UMD versions are located in `lib/turndown.umd.js` (for Node.js) and `lib/turndown.browser.umd.js` for browser usage. These files are generated when the npm package is published. To generate them manually, clone this repo and run `npm run build`.
 
+## Docker
+
+```
+docker build -t turndown .
+```
+
+Convert HTML piped via stdin to Markdown on stdout:
+
+```
+cat foo.html | docker run --rm -i turndown > foo.md
+```
+
+Convert a file in the current directory (mounted into the container) and write `foo.md` alongside it:
+
+```
+docker run --rm -v "$(pwd):/src" turndown foo.html
+```
+
 ## Usage
 
 ```js

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Browser:
 For usage with RequireJS, UMD versions are located in `lib/turndown.umd.js` (for Node.js) and `lib/turndown.browser.umd.js` for browser usage. These files are generated when the npm package is published. To generate them manually, clone this repo and run `npm run build`.
 
 ## Docker
+The Docker image uses the `turndown-plugin-gfm` to support tables.
 
 ```
 docker build -t turndown .

--- a/bin/turndown-cli.js
+++ b/bin/turndown-cli.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+var fs = require('fs')
+var path = require('path')
+var TurndownService = require('../lib/turndown.cjs.js')
+
+function readStdin () {
+  return fs.readFileSync(0, 'utf8')
+}
+
+function outputPathFor (inputPath) {
+  var ext = path.extname(inputPath)
+  var base = ext ? inputPath.slice(0, -ext.length) : inputPath
+  return base + '.md'
+}
+
+function main () {
+  var inputPath = process.argv[2]
+  var turndownService = new TurndownService()
+
+  var html = inputPath
+    ? fs.readFileSync(path.resolve(process.cwd(), inputPath), 'utf8')
+    : readStdin()
+
+  var markdown = turndownService.turndown(html)
+
+  if (inputPath) {
+    var outputPath = path.resolve(process.cwd(), outputPathFor(inputPath))
+    fs.writeFileSync(outputPath, markdown)
+  } else {
+    process.stdout.write(markdown)
+  }
+}
+
+main()

--- a/bin/turndown-cli.js
+++ b/bin/turndown-cli.js
@@ -18,6 +18,13 @@ function main () {
   var inputPath = process.argv[2]
   var turndownService = new TurndownService()
 
+  try {
+    var gfm = require('turndown-plugin-gfm').gfm
+    turndownService.use(gfm)
+  } catch (err) {
+    console.warn('turndown-plugin-gfm not installed; GFM extensions (tables, etc.) are disabled')
+  }
+
   var html = inputPath
     ? fs.readFileSync(path.resolve(process.cwd(), inputPath), 'utf8')
     : readStdin()


### PR DESCRIPTION
- Adds a Dockerfile and entrypoint helper script
- Updates README to include build and run instructions
- Can either convert HTML stdin to Markdown stdout or can use a mount to convert a .html file to .md.

# README
---

## Docker
The Docker image uses the `turndown-plugin-gfm` to support tables.

```
docker build -t turndown .
```

Convert HTML piped via stdin to Markdown on stdout:

```
cat foo.html | docker run --rm -i turndown > foo.md
```

Convert a file in the current directory (mounted into the container) and write `foo.md` alongside it:

```
docker run --rm -v "$(pwd):/src" turndown foo.html
```
---